### PR TITLE
Added link to documentation at the top of all the product _data.yaml files

### DIFF
--- a/docs/data/archive/aquatic-surface-reflectance-landsat/_data.yaml
+++ b/docs/data/archive/aquatic-surface-reflectance-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: Aquatic Surface Reflectance (Landsat)

--- a/docs/data/archive/clone-of-dea-wetlands-insight-tool-qld/_data.yaml
+++ b/docs/data/archive/clone-of-dea-wetlands-insight-tool-qld/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Wetlands Insight Tool (QLD)

--- a/docs/data/archive/clone-of-dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
+++ b/docs/data/archive/clone-of-dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Wetlands Insight Tool (Ramsar Wetlands)

--- a/docs/data/archive/dea-cloud-and-cloud-shadow-mask-sentinel-2-msi/_data.yaml
+++ b/docs/data/archive/dea-cloud-and-cloud-shadow-mask-sentinel-2-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Cloud and Cloud Shadow Mask (Sentinel-2 MSI)

--- a/docs/data/archive/dea-collection-3-grid-specification/_data.yaml
+++ b/docs/data/archive/dea-collection-3-grid-specification/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Collection 3 Grid Specification

--- a/docs/data/archive/dea-intertidal-suite-draft-product-testing-only/_data.yaml
+++ b/docs/data/archive/dea-intertidal-suite-draft-product-testing-only/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Intertidal Suite (Draft - Product Testing only)

--- a/docs/data/archive/dea-land-cover-landsat-abs-draft/_data.yaml
+++ b/docs/data/archive/dea-land-cover-landsat-abs-draft/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Land Cover (Landsat) - ABS [draft]

--- a/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
+++ b/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DRAFT - DEA Land Cover (Landsat)

--- a/docs/data/archive/draft-dea-waterbodies-landsat/_data.yaml
+++ b/docs/data/archive/draft-dea-waterbodies-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DRAFT DEA Waterbodies (Landsat)

--- a/docs/data/old-version/_data.yaml
+++ b/docs/data/old-version/_data.yaml
@@ -1,2 +1,5 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 title: Old versions of products
 description: This page lists the old versions of all products. They are grouped alphabetically (A to Z) for convenience.

--- a/docs/data/old-version/dea-burnt-area-landsat-2010-and-2015-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-burnt-area-landsat-2010-and-2015-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Burnt Area (Landsat, 2010 and 2015)

--- a/docs/data/old-version/dea-burnt-area-vectors-sentinel-2-near-real-time-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-burnt-area-vectors-sentinel-2-near-real-time-1.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Burnt Area Vectors Sentinel-2 Near Real-Time

--- a/docs/data/old-version/dea-fractional-cover-landsat-2.2.1/_data.yaml
+++ b/docs/data/old-version/dea-fractional-cover-landsat-2.2.1/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Fractional Cover (Landsat)

--- a/docs/data/old-version/dea-fractional-cover-percentiles-landsat-2.2.1/_data.yaml
+++ b/docs/data/old-version/dea-fractional-cover-percentiles-landsat-2.2.1/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Fractional Cover Percentiles (Landsat)

--- a/docs/data/old-version/dea-mangrove-canopy-cover-landsat-2.0.2/_data.yaml
+++ b/docs/data/old-version/dea-mangrove-canopy-cover-landsat-2.0.2/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Mangrove Canopy Cover (Landsat)

--- a/docs/data/old-version/dea-pixel-quality-count-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-pixel-quality-count-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Pixel Quality Count (Landsat)

--- a/docs/data/old-version/dea-pixel-quality-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-pixel-quality-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Pixel Quality (Landsat)

--- a/docs/data/old-version/dea-surface-reflectance-geomedian-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-geomedian-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance Geomedian (Landsat)

--- a/docs/data/old-version/dea-surface-reflectance-median-absolute-deviation-landsat-2.1.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-median-absolute-deviation-landsat-2.1.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance Median Absolute Deviation (Landsat)

--- a/docs/data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Landsat)

--- a/docs/data/old-version/dea-surface-reflectance-nbar-sentinel-2-msi-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbar-sentinel-2-msi-1.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Sentinel-2 MSI)

--- a/docs/data/old-version/dea-surface-reflectance-nbart-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbart-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Landsat)

--- a/docs/data/old-version/dea-surface-reflectance-nbart-sentinel-2-msi-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbart-sentinel-2-msi-1.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Sentinel-2 MSI)

--- a/docs/data/old-version/dea-water-observations-filtered-statistics-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-filtered-statistics-landsat-2.1.5/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations Filtered Statistics (Landsat)

--- a/docs/data/old-version/dea-water-observations-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-landsat-2.1.5/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations (Landsat)

--- a/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations Statistics (Landsat)

--- a/docs/data/old-version/dea-wetness-percentiles-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-wetness-percentiles-landsat-2.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Wetness Percentiles (Landsat)

--- a/docs/data/old-version/waterbodies-1.0.0/_data.yaml
+++ b/docs/data/old-version/waterbodies-1.0.0/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Waterbodies (Landsat)

--- a/docs/data/product/australian-geographic-reference-image/_data.yaml
+++ b/docs/data/product/australian-geographic-reference-image/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: Australian Geographic Reference Image

--- a/docs/data/product/australian-national-spectral-database/_data.yaml
+++ b/docs/data/product/australian-national-spectral-database/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: Australian National Spectral Database

--- a/docs/data/product/daily-satpaths-beta/_data.yaml
+++ b/docs/data/product/daily-satpaths-beta/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: Daily SatPaths

--- a/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
+++ b/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Burnt Area Characteristic Layers Sentinel-2 Near Real-Time

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Coastlines

--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Fractional Cover (Landsat)

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Fractional Cover Percentiles (Landsat)

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Geometric Median and Median Absolute Deviation (Landsat)

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA High and Low Tide Imagery (Landsat)

--- a/docs/data/product/dea-hotspots/_data.yaml
+++ b/docs/data/product/dea-hotspots/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Hotspots

--- a/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Intertidal Elevation (Landsat)

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Intertidal Extents (Landsat)

--- a/docs/data/product/dea-land-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-land-cover-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Land Cover (Landsat)

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Mangrove Canopy Cover (Landsat)

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance (Landsat 5 TM)

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance (Landsat 7 ETM+)

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance (Landsat 8 OLI-TIRS)

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance (Landsat 9)

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Landsat 5 TM)

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Landsat 7 ETM+)

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Landsat 8 OLI-TIRS)

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBAR (Landsat 9)

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Landsat 5 TM)

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Landsat 7 ETM+)

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Landsat 8 OLI-TIRS)

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Landsat 9)

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Sentinel-2A MSI)

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance NBART (Sentinel-2B MSI)

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Landsat 5 TM)

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Landsat 7 ETM+)

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Landsat 8 OLI-TIRS)

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Landsat 9)

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Sentinel-2A MSI)

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance OA (Sentinel-2B MSI)

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: " DEA Surface Reflectance (Sentinel-2A MSI)"

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Surface Reflectance (Sentinel-2B MSI)

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Tasseled Cap Percentiles (Landsat)

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations (Landsat)

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations (Sentinel-2 NRT)

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Water Observations Statistics (Landsat)

--- a/docs/data/product/dea-waterbodies-landsat/_data.yaml
+++ b/docs/data/product/dea-waterbodies-landsat/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Waterbodies (Landsat)

--- a/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: DEA Wetlands Insight Tool (QLD)

--- a/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: " DEA Wetlands Insight Tool (Ramsar Wetlands)"

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -1,3 +1,6 @@
+# See the Product metadata fields documentation:
+# https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
+
 # Overview
 
 title: Geoscience Australia Land Cover (Terra MODIS)

--- a/starter-kits/product/_data.yaml
+++ b/starter-kits/product/_data.yaml
@@ -1,4 +1,4 @@
-# See the documentation for each of these metadata fields:
+# See the Product metadata fields documentation:
 # https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html
 
 # Overview


### PR DESCRIPTION
The intention of this PR is to make the Product metadata fields documentation more discoverable.

This PR also ensures that the same comment is added to the Product Starter Kit.

<!-- Enter 'x' into the checkbox to confirm (if applicable). -->

* [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [ ] If required, update the [DEA Tech Alerts and Changelog](TechAlertsChangelog) and the [DEA Sandbox Updates banner](SandboxUpdatesBanner).

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-docs/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml
