### PR TITLE
Updated references to old repo name 'dea-docs'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@
 * [ ] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
 * [ ] If required, update the [DEA Tech Alerts and Changelog](TechAlertsChangelog) and the [DEA Sandbox Updates banner](SandboxUpdatesBanner).
 
-[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-docs/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
 [SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ run:
 	make start
 
 build:
-	docker build -t dea-docs .
+	docker build -t dea-knowledge-hub .
 
 rebuild:
-	docker build --no-cache -t dea-docs .
+	docker build --no-cache -t dea-knowledge-hub .
 
 start:
-	docker run -it --rm --name dea-docs --publish 8062:8062 --volume ./docs/notebooks:/docs/notebooks --volume ./output:/output --env-file .env dea-docs \
+	docker run -it --rm --name dea-knowledge-hub --publish 8062:8062 --volume ./docs/notebooks:/docs/notebooks --volume ./output:/output --env-file .env dea-knowledge-hub \
 	| grep --invert-match --regexp "WARNING.*Document headings start at" \
 	| grep --invert-match --regexp "WARNING.*duplicate label" \
 	| grep --invert-match --regexp "^copying images..." \
@@ -21,7 +21,7 @@ start:
 	| grep --invert-match --regexp ".*GET /_images.*"
 
 ssh:
-	docker exec -it dea-docs /bin/sh
+	docker exec -it dea-knowledge-hub /bin/sh
 
 test-redirects:
 	npx mocha ./aws/cloudfront/functions/*.js

--- a/docs/_modules/deploy_banner.py
+++ b/docs/_modules/deploy_banner.py
@@ -9,7 +9,7 @@ def banner():
 
     knowledge_hub_url = "https://knowledge.dea.ga.gov.au/"
     github_url = "https://github.com/GeoscienceAustralia/dea-knowledge-hub"
-    deploy_logs_url = "https://app.netlify.com/sites/dea-knowledge-hub/deploys"
+    deploy_logs_url = "https://app.netlify.com/sites/dea-docs/deploys"
 
     pull_request_banner = f'You are viewing <strong>{deploy_name} #{review_id}</strong>, not the official <a href="{knowledge_hub_url}">DEA Knowledge Hub</a>. View the <a href="{deploy_logs_url}/{deploy_id}">Deploy log</a> or <a href="{github_url}/pull/{review_id}">Pull request</a>.'
 

--- a/docs/_modules/deploy_banner.py
+++ b/docs/_modules/deploy_banner.py
@@ -8,8 +8,8 @@ def banner():
     deploy_id = os.environ.get("DEPLOY_ID")
 
     knowledge_hub_url = "https://knowledge.dea.ga.gov.au/"
-    github_url = "https://github.com/GeoscienceAustralia/dea-docs"
-    deploy_logs_url = "https://app.netlify.com/sites/dea-docs/deploys"
+    github_url = "https://github.com/GeoscienceAustralia/dea-knowledge-hub"
+    deploy_logs_url = "https://app.netlify.com/sites/dea-knowledge-hub/deploys"
 
     pull_request_banner = f'You are viewing <strong>{deploy_name} #{review_id}</strong>, not the official <a href="{knowledge_hub_url}">DEA Knowledge Hub</a>. View the <a href="{deploy_logs_url}/{deploy_id}">Deploy log</a> or <a href="{github_url}/pull/{review_id}">Pull request</a>.'
 

--- a/make.bat
+++ b/make.bat
@@ -1,7 +1,7 @@
 REM This is the script for building the site locally on Windows. In the Command Prompt, enter the command:
 REM make.bat
 
-docker build -t dea-docs .
+docker build -t dea-knowledge-hub .
 
-docker run -it --rm --name dea-docs --publish 8062:8062 --volume ".\docs\notebooks":"/docs/notebooks" --volume ".\output":"/output" --env-file .env dea-docs
+docker run -it --rm --name dea-knowledge-hub --publish 8062:8062 --volume ".\docs\notebooks":"/docs/notebooks" --volume ".\output":"/output" --env-file .env dea-knowledge-hub
 


### PR DESCRIPTION
Some references to the old repo name 'dea-docs' existed in the repo, so I updated them to use the new name 'dea-knowledge-hub'. This also involved updating a few links.