### PR TITLE
Minor changes to Tech Alerts Changelog code

### DIFF
--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,5 +1,5 @@
 :::{admonition} DEA system status:
-:class: caution % Change this to either: tip / caution / danger
+:class: caution  % Change this to either: tip / caution / danger
 
 2024-03-14: We have implemented changes to improve the intermittent performance issues being experienced on DEA web services. We are continuing to work to fix this issue.
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,7 +1,7 @@
 % See the DEA Tech Alerts and Changelog documentation:
 % https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
 
-:::{admonition} DEA system status
+:::{admonition} DEA System Status
 :class: caution
 % Change the 'class' to either: tip / caution / danger
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -2,7 +2,8 @@
 % https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
 
 :::{admonition} DEA system status:
-:class: caution  % Change this to either: tip / caution / danger
+:class: caution
+% Change the 'class' to either: tip / caution / danger
 
 2024-03-14: We have implemented changes to improve the intermittent performance issues being experienced on DEA web services. We are continuing to work to fix this issue.
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,7 +1,7 @@
 % See the DEA Tech Alerts and Changelog documentation:
 % https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
 
-:::{admonition} DEA system status:
+:::{admonition} DEA system status
 :class: caution
 % Change the 'class' to either: tip / caution / danger
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,13 +1,9 @@
-% If status = green, class = tip
-% All DEA systems are working as expected. There are no outstanding incidents or errors to report.
-% See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/). 
-% If status = yellow, class = caution
-% If status = red, class = danger
-
-:::{admonition} DEA system status: yellow
-:class: caution
+:::{admonition} DEA system status:
+:class: caution % Change this to either: tip / caution / danger
 
 2024-03-14: We have implemented changes to improve the intermittent performance issues being experienced on DEA web services. We are continuing to work to fix this issue.
+
+% All DEA systems are working as expected. There are no outstanding incidents or errors to report.
 
 See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/) to check the current status of DEA's services.
 :::

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,3 +1,6 @@
+% See the DEA Tech Alerts and Changelog documentation:
+% https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
+
 :::{admonition} DEA system status:
 :class: caution  % Change this to either: tip / caution / danger
 


### PR DESCRIPTION
The intention of this PR is to make this file as simple and easy for stakeholders as possible.

* Added link to documentation at top of code file.
* Removed the system status word "yellow" since the status is already indicated by the colour of the callout box.
* Replaced some of the code comments at the top of the file with a comment that says `% Change this to either: tip / caution / danger`
* Moved a code comment from the top of the file to inside the callout box: `% All DEA systems are working as expected. There are no outstanding incidents or errors to report.`