### PR TITLE
Proposal to remove Windows support

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,7 +1,0 @@
-REM This is the script for building the site locally on Windows. In the Command Prompt, enter the command:
-REM make.bat
-
-docker build -t dea-knowledge-hub .
-
-docker run -it --rm --name dea-knowledge-hub --publish 8062:8062 --volume ".\docs\notebooks":"/docs/notebooks" --volume ".\output":"/output" --env-file .env dea-knowledge-hub
-


### PR DESCRIPTION
Reasons for this proposal:

* The new PR Preview feature will be used by stakeholders instead of building locally on a Windows machine.
* The only people who will build it locally are developers working on the site (e.g. me) but most developers use Mac/Linux.
* If a developer is using Windows, they will have the ability to develop a Windows build script and test it themselves.
* Therefore, testing and maintaining this Windows build script is not a good use of our time and we should delete it.