### PR TITLE
Added a command to skip or disable previewing a PR

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -19,6 +19,10 @@ permissions:
 jobs:
   pr-preview:
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, '[skip preview]') &&
+      !contains(github.event.pull_request.title, '[skip preview]') &&
+      !contains(github.event.pull_request.body, '[skip preview]')
 
     strategy:
       matrix:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  publish:
+  pr-preview:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -10,6 +10,7 @@ env:
   PR_PREVIEW_SUBDOMAIN: pr-${{github.event.pull_request.number}}-preview
   PR_PREVIEW_DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   PR_PREVIEW_BUCKET: s3://khpreview.dea.ga.gov.au
+  PR_PREVIEW_SKIP_COMMAND: "[no preview]"
 
 permissions:
   id-token: write # For requesting the JWT used by OIDC Authentication
@@ -20,9 +21,9 @@ jobs:
   pr-preview:
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[skip preview]') &&
-      !contains(github.event.pull_request.title, '[skip preview]') &&
-      !contains(github.event.pull_request.body, '[skip preview]')
+      !contains(github.event.head_commit.message, '${{ env.PR_PREVIEW_SKIP_COMMAND }}') &&
+      !contains(github.event.pull_request.title, '${{ env.PR_PREVIEW_SKIP_COMMAND }}') &&
+      !contains(github.event.pull_request.body, '${{ env.PR_PREVIEW_SKIP_COMMAND }}')
 
     strategy:
       matrix:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -10,7 +10,8 @@ env:
   PR_PREVIEW_SUBDOMAIN: pr-${{github.event.pull_request.number}}-preview
   PR_PREVIEW_DEPLOY_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   PR_PREVIEW_BUCKET: s3://khpreview.dea.ga.gov.au
-  PR_PREVIEW_SKIP_COMMAND: "[no preview]"
+  PR_PREVIEW_SKIP_COMMAND_1: "[no preview]"
+  PR_PREVIEW_SKIP_COMMAND_2: "[skip preview]"
 
 permissions:
   id-token: write # For requesting the JWT used by OIDC Authentication
@@ -21,9 +22,12 @@ jobs:
   pr-preview:
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '${{ env.PR_PREVIEW_SKIP_COMMAND }}') &&
-      !contains(github.event.pull_request.title, '${{ env.PR_PREVIEW_SKIP_COMMAND }}') &&
-      !contains(github.event.pull_request.body, '${{ env.PR_PREVIEW_SKIP_COMMAND }}')
+      !contains(github.event.head_commit.message, '${{ env.PR_PREVIEW_SKIP_COMMAND_1 }}') &&
+      !contains(github.event.head_commit.message, '${{ env.PR_PREVIEW_SKIP_COMMAND_2 }}') &&
+      !contains(github.event.pull_request.title, '${{ env.PR_PREVIEW_SKIP_COMMAND_1 }}') &&
+      !contains(github.event.pull_request.title, '${{ env.PR_PREVIEW_SKIP_COMMAND_2 }}') &&
+      !contains(github.event.pull_request.body, '${{ env.PR_PREVIEW_SKIP_COMMAND_1 }}') &&
+      !contains(github.event.pull_request.body, '${{ env.PR_PREVIEW_SKIP_COMMAND_2 }}')
 
     strategy:
       matrix:


### PR DESCRIPTION
* Add a command `[no preview]` or alternatively `[skip preview]`
* If added to a commit message, it skips rebuilding the PR preview.
* If added to a PR title or body, it disables rebuilding the PR previews.