### PR TITLE
Changed the style of the 'Old version' callout box

### DIFF
--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -81,7 +81,7 @@
 
    {% if not is_latest_version %}
    .. admonition:: Old version
-      :class: danger
+      :class: note
    
       This is an old version of the product. See the `latest version <{{ data.latest_version_link }}>`_.
 


### PR DESCRIPTION
Changed the style of this callout box from red ('danger') to blue ('note') so it is less intrusive for the reader.