### PR TITLE
Aligned the starter kit headings with our documentation

### DIFF
--- a/starter-kits/product/_details.md
+++ b/starter-kits/product/_details.md
@@ -1,8 +1,6 @@
 % ## Background
 
-## Purpose
-
-% ## Applications
+## Applications
 
 ## Technical information
 


### PR DESCRIPTION
Some headings in the starter kit weren't correct according to our documentation so I fixed them.