### PR TITLE
Removed the skip conditions from github action

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -20,13 +20,6 @@ permissions:
 jobs:
   pr-preview:
     runs-on: ubuntu-latest
-    if: |
-      !contains(github.event.head_commit.message, '[no preview]') &&
-      !contains(github.event.head_commit.message, '[skip preview]') &&
-      !contains(github.event.pull_request.title, '[no preview]') &&
-      !contains(github.event.pull_request.title, '[skip preview]') &&
-      !contains(github.event.pull_request.body, '[no preview]') &&
-      !contains(github.event.pull_request.body, '[skip preview]')
 
     strategy:
       matrix:


### PR DESCRIPTION
This is because the functionality is now provided out of the box: <https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs>