### PR TITLE
Added citation to the Publications page

### DIFF
--- a/docs/guides/about/publications.rst
+++ b/docs/guides/about/publications.rst
@@ -12,7 +12,7 @@ Scientific articles, conference talks and other publications with Digital Earth 
 2024
 ****
 
-Byrne, G. et al., 2024. Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8. Remote Sensing, 16, p. 1233. http://dx.doi.org/10.3390/rs16071233
+Byrne, G., Broomhall, M., Walsh, A., Thankappan, M., Hay, E., Li, F., McAtee, B., Garcia, R., Anstee, J., Kerrisk, G., Drayson, N., Barnetson, J., Samford, I., Denham, R., 2024. Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8. Remote Sensing, 16, p. 1233. http://dx.doi.org/10.3390/rs16071233
 
 ****
 2023

--- a/docs/guides/about/publications.rst
+++ b/docs/guides/about/publications.rst
@@ -9,6 +9,12 @@ Scientific articles, conference talks and other publications with Digital Earth 
    :backlinks: none
 
 ****
+2024
+****
+
+Byrne, G. et al. (03 2024) ‘Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8’, Remote Sensing, 16, p. 1233. doi: 10.3390/rs16071233.
+
+****
 2023
 ****
 

--- a/docs/guides/about/publications.rst
+++ b/docs/guides/about/publications.rst
@@ -12,7 +12,7 @@ Scientific articles, conference talks and other publications with Digital Earth 
 2024
 ****
 
-Byrne, G. et al. (03 2024) ‘Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8’, Remote Sensing, 16, p. 1233. doi: 10.3390/rs16071233.
+Byrne, G. et al., 2024. Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8. Remote Sensing, 16, p. 1233. http://dx.doi.org/10.3390/rs16071233
 
 ****
 2023


### PR DESCRIPTION
Validating Digital Earth Australia NBART for the Landsat 9 Underfly of Landsat 8

https://www.researchgate.net/publication/379453815_Validating_Digital_Earth_Australia_NBART_for_the_Landsat_9_Underfly_of_Landsat_8