### PR TITLE
2018 DEA Public Data Changes changelog entries

### DIFF
--- a/docs/tech-alerts-changelog/previous-years/2018.md
+++ b/docs/tech-alerts-changelog/previous-years/2018.md
@@ -5,28 +5,28 @@
 
 ## 2018-12-05: DEA Public Data Changes
 
-- Added Land/Sea mask GeoTIFFs to /projects/geodata_coast_100k/
-- Updated csv files in /projects/WaterBodies/feature_info with latest data, ISO timestamps and changed column order
+* Added Land/Sea mask GeoTIFFs to `/projects/geodata_coast_100k/`
+* Updated CSV files in `/projects/WaterBodies/feature_info` with latest data, ISO timestamps, and changed column order.
 
 ## 2018-11-12: DEA Public Data Changes
 
-- Update website components to match DEA styling
-- Change time to more readable format
-- Replace images 
+* Update website components to match DEA styling.
+* Change time to more readable format.
+* Replace images.
 
 ## 2018-11-06: DEA Public Data Changes
 
-- Updated csv files in /projects/WaterBodies/feature_info
+- Updated CSV files in `/projects/WaterBodies/feature_info`
 
 ## 2018-11-05: DEA Public Data Changes
 
-- Added /Website
-- Updated index.html to improve user interface and experience.
+- Added `/Website`
+- Updated `index.html` to improve user interface and experience.
 
 ## 2018-10-11: DEA Public Data Changes
 
-- Added /CHANGELOG.txt
-- Replaced /geomedian-australia/v2.1.0/albers_grid.geojson with a version using WGS84 coordinates, as per the GeoJSON specification.
+- Added `/CHANGELOG.txt`
+- Replaced `/geomedian-australia/v2.1.0/albers_grid.geojson` with a version using WGS84 coordinates, as per the GeoJSON specification.
 
 ## 2018-02-28: Update to 'dea' environment module
 
@@ -39,6 +39,6 @@
     ```bash
     jupyter-lab
     ```
-* Include pre-release version 1.6 of Open Data Cube
-* Drop support for Python 2
+* Include pre-release version 1.6 of Open Data Cube.
+* Drop support for Python 2.
 

--- a/docs/tech-alerts-changelog/previous-years/2018.md
+++ b/docs/tech-alerts-changelog/previous-years/2018.md
@@ -3,6 +3,31 @@
 :::{include} ./_components/previous-years-introduction.md
 :::
 
+## 2018-12-05: DEA Public Data Changes
+
+- Added Land/Sea mask GeoTIFFs to /projects/geodata_coast_100k/
+- Updated csv files in /projects/WaterBodies/feature_info with latest data, ISO timestamps and changed column order
+
+## 2018-11-12: DEA Public Data Changes
+
+- Update website components to match DEA styling
+- Change time to more readable format
+- Replace images 
+
+## 2018-11-06: DEA Public Data Changes
+
+- Updated csv files in /projects/WaterBodies/feature_info
+
+## 2018-11-05: DEA Public Data Changes
+
+- Added /Website
+- Updated index.html to improve user interface and experience.
+
+## 2018-10-11: DEA Public Data Changes
+
+- Added /CHANGELOG.txt
+- Replaced /geomedian-australia/v2.1.0/albers_grid.geojson with a version using WGS84 coordinates, as per the GeoJSON specification.
+
 ## 2018-02-28: Update to 'dea' environment module
 
 * Rename module to `dea`. Most people should now run the following commands from the terminal.


### PR DESCRIPTION
Migrated this changelog from the Digital Earth Australia - Public Data folder: <https://data.dea.ga.gov.au/?prefix=derivative/>