### PR TITLE
Update NIDEM access links given eCat listing being superseded

### DIFF
--- a/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
@@ -56,10 +56,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: http://pid.geoscience.gov.au/dataset/ga/123678
-    name: Download the "NIDEM mosaic"
+  - link: https://data.dea.ga.gov.au/?prefix=nidem/
+    name: Access the data on AWS
   - link: http://dapds00.nci.org.au/thredds/catalogs/fk4/nidem_1_0.html
-    name: Access the Data on NCI
+    name: Access the data on NCI
 
 code_examples: null
 

--- a/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
@@ -34,8 +34,8 @@ licence:
   link: https://creativecommons.org/licenses/by/4.0/
 
 citations:
-  data_citation: Bishop-Taylor, R., Sagar, S., Lymburner, L. 2018. National Intertidal Digital Elevation Model 25m 1.0.0. Geoscience Australia, Canberra. http://dx.doi.org/10.26186/5c4fc06a79f76
-  paper_citation: Bishop-Taylor, R., Sagar, S., Lymburner, L., Beaman, R.L., 2019. Between the tides: modelling the elevation of Australia's exposed intertidal zone at continental scale. Estuarine, Coastal and Shelf Science. https://doi.org/10.1016/j.ecss.2019.03.006
+  data_citation: "Bishop-Taylor, R., Sagar, S., Lymburner, L. 2018. National Intertidal Digital Elevation Model 25m 1.0.0. Geoscience Australia, Canberra. http://dx.doi.org/10.26186/5c4fc06a79f76"
+  paper_citation: "Bishop-Taylor, R., Sagar, S., Lymburner, L., Beaman, R.L., 2019. Between the tides: modelling the elevation of Australia's exposed intertidal zone at continental scale. Estuarine, Coastal and Shelf Science. https://doi.org/10.1016/j.ecss.2019.03.006"
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
@@ -34,8 +34,8 @@ licence:
   link: https://creativecommons.org/licenses/by/4.0/
 
 citations:
-  data_citation: null
-  paper_citation: null
+  data_citation: Bishop-Taylor, R., Sagar, S., Lymburner, L. 2018. National Intertidal Digital Elevation Model 25m 1.0.0. Geoscience Australia, Canberra. http://dx.doi.org/10.26186/5c4fc06a79f76
+  paper_citation: Bishop-Taylor, R., Sagar, S., Lymburner, L., Beaman, R.L., 2019. Between the tides: modelling the elevation of Australia's exposed intertidal zone at continental scale. Estuarine, Coastal and Shelf Science. https://doi.org/10.1016/j.ecss.2019.03.006
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated
@@ -65,7 +65,7 @@ code_examples: null
 
 web_services:
   - link: https://ows.services.dea.ga.gov.au
-    name: Web Services
+    name: Web Map Service (WMS)
 
 custom: null
 


### PR DESCRIPTION
We are preparing to have the NIDEM eCat listing marked as "superseded". This will cause the listing to lose its existing access links, which will be replaced with a single link forwarding users to the new DEA Intertidal eCat page. This means that the current "mosaics" access link on this page will no longer be useful. 

This PR updates the access link to point to our data on AWS directly, which will be more useful for our users.

Also adds some citations to the NIDEM page.
