### PR TITLE
Removed update_frequency fields on Deprecated products

### DIFF
--- a/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
@@ -15,7 +15,7 @@ spatial_data_type: Raster
 time_span:
   start: null
   end: null
-update_frequency: Periodically
+update_frequency: null # Periodically
 next_update: null
 product_ids:
   - wofs_summary

--- a/docs/data/old-version/waterbodies-1.0.0/_data.yaml
+++ b/docs/data/old-version/waterbodies-1.0.0/_data.yaml
@@ -15,7 +15,7 @@ spatial_data_type: Raster
 time_span:
   start: null
   end: null
-update_frequency: Monthly
+update_frequency: null # Monthly
 next_update: null
 product_ids: null
 


### PR DESCRIPTION
The 'Update frequency' field on two Deprecated products were no longer relevant so I removed them.