### PR TITLE
Removed 'sandbox' from the DEA Explorer URLs

### DIFF
--- a/docs/data/archive/draft-dea-land-cover-landsat/_access.md
+++ b/docs/data/archive/draft-dea-land-cover-landsat/_access.md
@@ -32,7 +32,7 @@ DEA Land Cover data can be downloaded from DEA’s public data holdings through 
 
 From [here](https://data.dea.ga.gov.au/?prefix=derivative/ga_ls_landcover_class_cyear_2/1-0-0/), simply navigate to the year and tile\* of interest and directly download the GeoTIFF file for the layer you’re after.
 
-*\*To find x and y tile values for an area, see the Explorer [here](https://explorer.sandbox.dea.ga.gov.au/products/ga_ls_landcover_class_cyear_2).*
+*\*To find x and y tile values for an area, see the Explorer [here](https://explorer.dea.ga.gov.au/products/ga_ls_landcover_class_cyear_2).*
 
 ***Bulk download using AWS CLI (for technical users):***
 

--- a/docs/guides/setup/AWS/data_and_metadata.rst
+++ b/docs/guides/setup/AWS/data_and_metadata.rst
@@ -15,8 +15,8 @@ Data and services listing
 -------------------------
 
 * `Browse the public S3 bucket <https://data.dea.ga.gov.au/>`_ via the web.
-* `DEA Explorer <https://explorer.sandbox.dea.ga.gov.au/>`_ allows browsing geographic extent through time of every dataset we have available.
-* The `DEA Explorer STAC endpoint <https://explorer.sandbox.dea.ga.gov.au/stac/>`_ provides an API for listing and searching DEA Datasets.
+* `DEA Explorer <https://explorer.dea.ga.gov.au/>`_ allows browsing geographic extent through time of every dataset we have available.
+* The `DEA Explorer STAC endpoint <https://explorer.dea.ga.gov.au/stac/>`_ provides an API for listing and searching DEA Datasets.
 * Open Geospatial Consortium Web Services are available through our `Open Web Service <https://ows.dea.ga.gov.au/>`_ and provide access to visualisations and data exports via WMS, WMTS and WCS.
 * Execute custom Python code within the `DEA JupyterHub Sandbox <https://app.sandbox.dea.ga.gov.au/>`_ (see `DEA Sandbox`_ for more details).
 

--- a/docs/guides/setup/gis/stac.ipynb
+++ b/docs/guides/setup/gis/stac.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog = pystac_client.Client.open('https://explorer.sandbox.dea.ga.gov.au/stac')"
+    "catalog = pystac_client.Client.open('https://explorer.dea.ga.gov.au/stac')"
    ]
   },
   {


### PR DESCRIPTION
Reviewer: @robbibt 

I removed 'sandbox' from the DEA Explorer URLs so that they use the new URL format which reduces confusion for the user.

Note: We may need to wait until the Explorer is back online to test that these new URLs are working.