### PR TITLE
Custom 'Cite this product' citations

### DIFF
--- a/docs/_static/scripts/citation-access-date.js
+++ b/docs/_static/scripts/citation-access-date.js
@@ -25,10 +25,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
         return `${citationTrimmed} [Accessed ${day} ${month} ${year}]`;
     }
 
-    const citations = [
-        document.getElementById("data-citation"),
-        document.getElementById("paper-citation")
-    ];
+    const citations = document.getElementsByClassName(
+        "citation-table-citation"
+    );
 
     for (let i = 0; i < citations.length; i++) {
         const citation = citations[i];

--- a/docs/_static/scripts/citation-access-date.js
+++ b/docs/_static/scripts/citation-access-date.js
@@ -25,9 +25,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         return `${citationTrimmed} [Accessed ${day} ${month} ${year}]`;
     }
 
-    const citations = document.getElementsByClassName(
-        "citation-table-citation"
-    );
+    const citations = document.getElementsByClassName("citation-access-date");
 
     for (let i = 0; i < citations.length; i++) {
         const citation = citations[i];

--- a/docs/_static/styles/components/_citation_table.scss
+++ b/docs/_static/styles/components/_citation_table.scss
@@ -1,5 +1,5 @@
 #citation-table {
-    #data-citation, #paper-citation {
+    .citation {
         margin: 0 !important;
 
         .highlight {

--- a/docs/_static/styles/components/_citation_table.scss
+++ b/docs/_static/styles/components/_citation_table.scss
@@ -19,6 +19,8 @@
             white-space: -pre-wrap;
             white-space: -o-pre-wrap;
             word-wrap: break-word;
+            padding-top: 4px;
+            padding-bottom: 4px;
         }
     }
 

--- a/docs/_static/styles/components/_citation_table.scss
+++ b/docs/_static/styles/components/_citation_table.scss
@@ -1,5 +1,5 @@
 #citation-table {
-    .citation {
+    .citation-table-citation {
         margin: 0 !important;
 
         .highlight {

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -10,6 +10,7 @@
 {% set valid_old_versions = data.old_versions | selectattr("slug",  "!=", None) | selectattr("version",  "!=", None) | selectattr("name",  "!=", None) | list %}
 {% set valid_product_types = [data.product_type, data.spatial_data_type] | select("!=", None) | list %}
 {% set valid_product_ids = data.product_ids | select("!=", None) | list %}
+{% set valid_custom_citations = data.custom_citations | select("!=", None) | list %}
 {% set valid_tags = data.tags | select("!=", None) | list %}
 
 {% set map_label = "See it on a map" %}
@@ -246,7 +247,7 @@
 
                  {{ data.citations.paper_citation }}
           {%- endif %}
-          {% for citation in data.custom_citations %}
+          {% for citation in valid_custom_citations %}
           * - **{{ citation.name }}**
             - .. code-block:: text
                  :class: citation

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -234,7 +234,7 @@
           {% if data.citations.data_citation %}
           * - **Data citation**
             - .. code-block:: text
-                 :class: citation-table-citation
+                 :class: citation-table-citation citation-access-date
 
                  {{ data.citations.data_citation }}
           {%- endif %}

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -234,23 +234,21 @@
           {% if data.citations.data_citation %}
           * - **Data citation**
             - .. code-block:: text
-                 :name: data-citation
-                 :class: citation
+                 :class: citation-table-citation
 
                  {{ data.citations.data_citation }}
           {%- endif %}
           {% if data.citations.paper_citation %}
           * - **Paper citation**
             - .. code-block:: text
-                 :name: paper-citation
-                 :class: citation
+                 :class: citation-table-citation
 
                  {{ data.citations.paper_citation }}
           {%- endif %}
           {% for citation in valid_custom_citations %}
           * - **{{ citation.name }}**
             - .. code-block:: text
-                 :class: citation
+                 :class: citation-table-citation
 
                  {{ citation.citation }}
           {% endfor %}

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -234,6 +234,7 @@
           * - **Data citation**
             - .. code-block:: text
                  :name: data-citation
+                 :class: citation
 
                  {{ data.citations.data_citation }}
           {%- endif %}
@@ -241,9 +242,17 @@
           * - **Paper citation**
             - .. code-block:: text
                  :name: paper-citation
+                 :class: citation
 
                  {{ data.citations.paper_citation }}
           {%- endif %}
+          {% for citation in data.custom_citations %}
+          * - **{{ citation.name }}**
+            - .. code-block:: text
+                 :class: citation
+
+                 {{ citation.citation }}
+          {% endfor %}
        {%- endif %}
        {%- endif %}
 

--- a/docs/data/product/australian-geographic-reference-image/_data.yaml
+++ b/docs/data/product/australian-geographic-reference-image/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2011. AGRI: The Australian Geographic Reference Image. Geoscience Australia, Canberra. http://dx.doi.org/10.4225/25/5524BA4A047FE"
   paper_citation: null
+custom_citations: null
 
 tags:
   - agri

--- a/docs/data/product/australian-national-spectral-database/_data.yaml
+++ b/docs/data/product/australian-national-spectral-database/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2021. Australian National Spectral Database. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/145560"
   paper_citation: null
+custom_citations: null
 
 tags:
   - australian_remote_sensing

--- a/docs/data/product/daily-satpaths-beta/_data.yaml
+++ b/docs/data/product/daily-satpaths-beta/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia's predictive schedules for public good satellites over Australia. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146512"
   paper_citation: null
+custom_citations: null
 
 tags:
   - earth_observation

--- a/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
+++ b/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. DEA Burnt Area Characteristic Layers (Sentinel 2 Near Real-Time, Provisional). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146449"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -35,10 +35,7 @@ licence:
 citations:
   data_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Digital Earth Australia Coastlines. Geoscience Australia, Canberra. https://doi.org/10.26186/116268"
   paper_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
-# custom_citations: null
-custom_citations:
-  - name: Test citation
-    citation: Lorem ipsum dolor sit amet.
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -35,6 +35,9 @@ licence:
 citations:
   data_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Digital Earth Australia Coastlines. Geoscience Australia, Canberra. https://doi.org/10.26186/116268"
   paper_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
+custom_citations:
+  - name: Test citation
+    citation: Lorem ipsum dolor sit amet.
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -35,9 +35,7 @@ licence:
 citations:
   data_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Digital Earth Australia Coastlines. Geoscience Australia, Canberra. https://doi.org/10.26186/116268"
   paper_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
-custom_citations:
-  - name: Test citation
-    citation: Lorem ipsum dolor sit amet.
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -35,7 +35,10 @@ licence:
 citations:
   data_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Digital Earth Australia Coastlines. Geoscience Australia, Canberra. https://doi.org/10.26186/116268"
   paper_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
-custom_citations: null
+# custom_citations: null
+custom_citations:
+  - name: Test citation
+    citation: Lorem ipsum dolor sit amet.
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Lymburner, L., 2021. Geoscience Australia Landsat Fractional Cover Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/145498"
   paper_citation: "Scarth, P., Roder, A., Schmidt, M., 2010. Tracking grazing pressure and climate interaction - the role of Landsat fractional cover in time series analysis. Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference. http://dx.doi.org/10.6084/M9.FIGSHARE.94250"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Lymburner, L., 2021. Geoscience Australia Landsat Fractional Cover Percentiles Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/145501"
   paper_citation: "Scarth, P., Roder, A., Schmidt, M., 2010. Tracking grazing pressure and climate interaction - the role of Landsat fractional cover in time series analysis. Proceedings of the 15th Australasian Remote Sensing & Photogrammetry Conference. http://dx.doi.org/10.6084/M9.FIGSHARE.94250"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -38,6 +38,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. DEA Geometric Median and Median Absolute Deviation (Landsat). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146261"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -38,7 +38,11 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. DEA Geometric Median and Median Absolute Deviation (Landsat). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146261"
   paper_citation: null
-custom_citations: null
+custom_citations:
+  name: Geometric median paper citation
+  citation: "Roberts, D., Mueller, N., Mcintyre, A., 2017. High-dimensional pixel composites from earth observation time series. IEEE Transactions on Geoscience and Remote Sensing, 55(11), 6254–6264. https://doi.org/10.1109/TGRS.2017.2723896"
+  name: Median Absolute Deviation paper citation
+  citation: "Roberts, D., Dunn, B., Mueller, N., 2018. Open data cube products using high-dimensional statistics of time series. IGARSS 2018 - 2018 IEEE International Geoscience and Remote Sensing Symposium, 8647–8650. https://doi.org/10.1109/IGARSS.2018.8518312"
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -39,10 +39,10 @@ citations:
   data_citation: "Geoscience Australia, 2022. DEA Geometric Median and Median Absolute Deviation (Landsat). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146261"
   paper_citation: null
 custom_citations:
-  name: Geometric median paper citation
-  citation: "Roberts, D., Mueller, N., Mcintyre, A., 2017. High-dimensional pixel composites from earth observation time series. IEEE Transactions on Geoscience and Remote Sensing, 55(11), 6254–6264. https://doi.org/10.1109/TGRS.2017.2723896"
-  name: Median Absolute Deviation paper citation
-  citation: "Roberts, D., Dunn, B., Mueller, N., 2018. Open data cube products using high-dimensional statistics of time series. IGARSS 2018 - 2018 IEEE International Geoscience and Remote Sensing Symposium, 8647–8650. https://doi.org/10.1109/IGARSS.2018.8518312"
+  - name: Geometric median paper citation
+    citation: "Roberts, D., Mueller, N., Mcintyre, A., 2017. High-dimensional pixel composites from earth observation time series. IEEE Transactions on Geoscience and Remote Sensing, 55(11), 6254–6264. https://doi.org/10.1109/TGRS.2017.2723896"
+  - name: Median Absolute Deviation paper citation
+    citation: "Roberts, D., Dunn, B., Mueller, N., 2018. Open data cube products using high-dimensional statistics of time series. IGARSS 2018 - 2018 IEEE International Geoscience and Remote Sensing Symposium, 8647–8650. https://doi.org/10.1109/IGARSS.2018.8518312"
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -39,7 +39,7 @@ citations:
   data_citation: "Geoscience Australia, 2022. DEA Geometric Median and Median Absolute Deviation (Landsat). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146261"
   paper_citation: null
 custom_citations:
-  - name: Geometric median paper citation
+  - name: Geometric Median paper citation
     citation: "Roberts, D., Mueller, N., Mcintyre, A., 2017. High-dimensional pixel composites from earth observation time series. IEEE Transactions on Geoscience and Remote Sensing, 55(11), 6254–6264. https://doi.org/10.1109/TGRS.2017.2723896"
   - name: Median Absolute Deviation paper citation
     citation: "Roberts, D., Dunn, B., Mueller, N., 2018. Open data cube products using high-dimensional statistics of time series. IGARSS 2018 - 2018 IEEE International Geoscience and Remote Sensing Symposium, 8647–8650. https://doi.org/10.1109/IGARSS.2018.8518312"

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -37,6 +37,7 @@ licence:
 citations:
   data_citation: "Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2017. High tide and low tide composites 25m v. 2.0.0. Geoscience Australia, Canberra. http://dx.doi.org/10.4225/25/5a615705d20f7"
   paper_citation: "Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating continental scale pixel-based surface reflectance composites in coastal regions with the use of a multi-resolution tidal model. Remote Sensing. 10, 480. https://doi.org/10.3390/rs10030480"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-hotspots/_data.yaml
+++ b/docs/data/product/dea-hotspots/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2020. Digital Earth Australia Hotspots dataset. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/111881"
   paper_citation: null
+custom_citations: null
 
 tags:
   - bushfires

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Intertidal Extents Model 25m v. 2.0.0. Geoscience Australia, Canberra. http://dx.doi.org/10.4225/25/5a602cc9eb358"
   paper_citation: "Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153-169. https://doi.org/10.1016/j.rse.2017.04.009"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-intertidal/_data.yaml
+++ b/docs/data/product/dea-intertidal/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Bishop-Taylor, R., Phillips, C., Newey, V., Sagar, S.(2024). Digital Earth Australia Intertidal. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/149403"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-land-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-land-cover-landsat/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Tissott, B., Mueller, N., 2022. DEA Land Cover 25m. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146090"
   paper_citation: "Lucas, R., Mueller, N., Siggins, A., Owers, C., Clewley, D., Bunting, P., Kooymans, C., Tissott, B., Lewis, B., Lymburner, L., Metternicht, G., 2019. Land Cover Mapping using Digital Earth Australia. Data. 4(4):143. https://doi.org/10.3390/data4040143"
+custom_citations: null
 
 tags:
   - land_cover_and_land_use

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Lymburner, L., Lucas, R., Scarth, P., Alam, I., Phillips, C., Ticehurst, C., Held, A., Bunting, P. 2021. Geoscience Australia Mangrove Canopy Cover Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/145497"
   paper_citation: "Lymburner, L., Bunting, P., Lucas, R., Scarth, P., Alam, I., Phillips, C., Ticehurst, C. and Held, A., 2020. Mapping the multi-decadal mangrove dynamics of the Australian coastline. Remote Sensing of Environment, 238, p.111185. https://doi.org/10.1016/j.rse.2019.05.004"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M., 2019. GA Landsat 5 TM Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/130853"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 7 ETM+ Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132310"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 8 OLI/TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132317"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Alam, I., Chopra, A., Gray, D., Hooke, J., Li, F., Ly, L., Mettes, J., Miller, J., Norton, A., OHehir, A. 2023. Geoscience Australia Landsat 9 OLI TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/148693"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M., 2019. GA Landsat 5 TM Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/130853"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 7 ETM+ Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132310"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 8 OLI/TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132317"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Alam, I., Chopra, A., Gray, D., Hooke, J., Li, F., Ly, L., Mettes, J., Miller, J., Norton, A., OHehir, A. 2023. Geoscience Australia Landsat 9 OLI TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/148693"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M., 2019. GA Landsat 5 TM Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/130853"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 7 ETM+ Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132310"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 8 OLI/TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132317"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Alam, I., Chopra, A., Gray, D., Hooke, J., Li, F., Ly, L., Mettes, J., Miller, J., Norton, A., OHehir, A. 2023. Geoscience Australia Landsat 9 OLI TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/148693"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2A MSI NBART Collection 3 - DEA Surface Reflectance NBART (Sentinel-2A MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146571"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2B MSI NBART Collection 3 - DEA Surface Reflectance NBART (Sentinel-2B MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146569"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M., 2019. GA Landsat 5 TM Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/130853"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 7 ETM+ Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132310"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Fuqin, Li., Jupp, D.L.B., Sixsmith, J., Wang, L., Dorj, P., Vincent, A., Alam, I., Hooke, J., Oliver, S., Thankappan, M. 2019. GA Landsat 8 OLI/TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/132317"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Alam, I., Chopra, A., Gray, D., Hooke, J., Li, F., Ly, L., Mettes, J., Miller, J., Norton, A., OHehir, A. 2023. Geoscience Australia Landsat 9 OLI TIRS Analysis Ready Data Collection 3. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/148693"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2A Observation Attributes Collection 3 - DEA Surface Reflectance OA (Sentinel-2A MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146568"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2B Observation Attributes Collection 3 - DEA Surface Reflectance OA (Sentinel-2B MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146570"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2A MSI Analysis Ready Data Collection 3 - DEA Surface Reflectance (Sentinel-2A MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146552"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. Geoscience Australia Sentinel-2B MSI Analysis Ready Data Collection 3 - DEA Surface Reflectance (Sentinel-2B MSI). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146551"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -37,6 +37,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2023. DEA Tasseled Cap Percentiles (Landsat, Provisional). Geoscience Australia, Canberra."
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. DEA Water Observations. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146257"
   paper_citation: "Mueller, N., Lewis, A., Roberts, D., Ring, S., Melrose, R., Sixsmith, J., Lymburner, L., McIntyre, A., Tan, P., Curnow, S., & Ip, A., 2016. Water observations from space: Mapping surface water from 25 years of Landsat imagery across Australia. Remote Sensing of Environment, 174, 341–352. https://doi.org/10.1016/j.rse.2015.11.003"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2022. DEA Water Observations (Sentinel-2 NRT; Provisional). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146257"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -39,6 +39,7 @@ licence:
 citations:
   data_citation: "Mueller, N. 2022. Geoscience Australia Landsat Water Observation Statistics Collection 3. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146091"
   paper_citation: null
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-waterbodies-landsat/_data.yaml
+++ b/docs/data/product/dea-waterbodies-landsat/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Dunn, B., Krause, C., Newey, V., Lymburner, L., Alger, M.J., Adams, C., Yuan, F., Ma, S., Barzinpour, A., Ayers, D., McKenna, C., Schenk, L. 2024. Digital Earth Australia Waterbodies v3.0. Geoscience Australia, Canberra. https://dx.doi.org/10.26186/148920"
   paper_citation: "Krause, C.E., Newey, V., Alger, M.J. and Lymburner, L., 2021. Mapping and Monitoring the Multi-Decadal Dynamics of Australia’s Open Waterbodies using Landsat. Remote Sensing, 13, 1437. https://doi.org/10.3390/rs13081437"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2021. Wetlands Insight Tool Queensland Wetlands Polygons. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/144795"
   paper_citation: "Dunn, B., Ai, E., Alger, M.J., Fanson, B., Fickas, K.C., Krause, C.E., Lymburner, L., Nanson, R., Papas, P., Ronan, M., Thomas, R.F., 2023. Wetlands Insight Tool: Characterising the Surface Water and Vegetation Cover Dynamics of Individual Wetlands Using Multidecadal Landsat Satellite Data. Wetlands 43, 37. https://doi.org/10.1007/s13157-023-01682-7"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
@@ -35,6 +35,7 @@ licence:
 citations:
   data_citation: "Geoscience Australia, 2021. Wetlands Insight Tool Ramsar Wetlands Polygons. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/146165"
   paper_citation: "Dunn, B., Ai, E., Alger, M.J., Fanson, B., Fickas, K.C., Krause, C.E., Lymburner, L., Nanson, R., Papas, P., Ronan, M., Thomas, R.F., 2023. Wetlands Insight Tool: Characterising the Surface Water and Vegetation Cover Dynamics of Individual Wetlands Using Multidecadal Landsat Satellite Data. Wetlands 43, 37. https://doi.org/10.1007/s13157-023-01682-7"
+custom_citations: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -36,6 +36,7 @@ licence:
 citations:
   data_citation: "Lymburner, L., Tan, P., McIntyre, A., Thankappan, M., Sixsmith, J. 2015. Dynamic Land Cover Dataset Version 2.1. Geoscience Australia, Canberra. https://pid.geoscience.gov.au/dataset/ga/83868"
   paper_citation: null
+custom_citations: null
 
 tags:
   - drought

--- a/starter-kits/product/_data.yaml
+++ b/starter-kits/product/_data.yaml
@@ -36,6 +36,9 @@ licence:
 # citations:
 #   data_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Digital Earth Australia Coastlines. Geoscience Australia, Canberra. https://doi.org/10.26186/116268"
 #   paper_citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
+# custom_citations:
+#   - name: Custom citation
+#     citation: "Bishop-Taylor, R., Nanson, R., Sagar, S., Lymburner, L. (2021). Mapping Australia's dynamic coastline at mean sea level using three decades of Landsat imagery. Remote Sensing of Environment, 267, 112734. https://doi.org/10.1016/j.rse.2021.112734"
 
 # tags:
 #   - example_tag


### PR DESCRIPTION
The 'Cite this product' feature previously allowed up to two citations with hard-coded labels: Data citation and Paper citation.

Now, any number of citations can be added, with custom labels.

@CEKrause You mentioned that the Geomedian product needed additional citations. You can commit to this branch to see if it serves your purpose. E.g. you could add custom citations like this: 'Geomedian data citation', 'Geomedian paper citation', 'Geo-mean data citation', 'Geo-mean paper citation'.

```yaml
custom_citations:
  - name: Geomedian data citation
    citation: "Geoscience Australia, 2022. DEA Geometric Median and Median Absolute Deviation (Landsat). Geoscience Australia, Canberra. https://dx.doi.org/10.26186/146261"
```
