### PR TITLE
Adding the 'Follow our newsletter' link to the Tech Alerts page

### DIFF
--- a/docs/_templates/home-v1.rst
+++ b/docs/_templates/home-v1.rst
@@ -99,7 +99,7 @@
 
       `Visit the DEA website <https://www.dea.ga.gov.au/>`_
 
-      `Follow our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_
+      `Subscribe to our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_
 
    .. container::
 

--- a/docs/_templates/tech-alerts-changelog-v1.rst
+++ b/docs/_templates/tech-alerts-changelog-v1.rst
@@ -6,10 +6,6 @@
 
 {{ data.description }}
 
-To stay informed of the latest updates, `follow our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_
-
-To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_
-
 .. include:: _tech_alerts_changelog.md
    :parser: myst_parser.sphinx_
 

--- a/docs/_templates/tech-alerts-changelog-v1.rst
+++ b/docs/_templates/tech-alerts-changelog-v1.rst
@@ -6,6 +6,10 @@
 
 {{ data.description }}
 
+To stay informed of the latest updates, `follow our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_
+
+To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_
+
 .. include:: _tech_alerts_changelog.md
    :parser: myst_parser.sphinx_
 

--- a/docs/tech-alerts-changelog/_data.yaml
+++ b/docs/tech-alerts-changelog/_data.yaml
@@ -1,3 +1,3 @@
 title: DEA Tech Alerts and Changelog
-description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur.
+description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur. To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_. And, to stay informed of the latest updates, `follow our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_.
 

--- a/docs/tech-alerts-changelog/_data.yaml
+++ b/docs/tech-alerts-changelog/_data.yaml
@@ -1,3 +1,3 @@
 title: DEA Tech Alerts and Changelog
-description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur. To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_. And, to stay informed of the latest updates, `follow our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_.
+description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur. To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_. And, to stay informed of the latest updates, `subscribe to our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_.
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -9,8 +9,6 @@
 * Terra-derived DEA Hotspots are unavailable. See below.
 
 % All DEA systems are working as expected. There are no outstanding incidents or errors to report.
-
-See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/) to check the current status of DEA's services.
 :::
 
 ## 2024-05-13: Terra-derived DEA Hotspots are unavailable

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,14 +1,15 @@
 % See the DEA Tech Alerts and Changelog documentation:
 % https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
 
+% How to update the 'DEA System Status':
+% Change the 'class' to either: tip / caution / danger
+% Default content: All DEA systems are working as expected. There are no outstanding incidents or errors to report.
+
 :::{admonition} DEA System Status
 :class: caution
-% Change the 'class' to either: tip / caution / danger
 
 * Performance issues with DEA Explorer and STAC API. See below.
 * Terra-derived DEA Hotspots are unavailable. See below.
-
-% All DEA systems are working as expected. There are no outstanding incidents or errors to report.
 :::
 
 ## 2024-05-13: Terra-derived DEA Hotspots are unavailable

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -1,11 +1,11 @@
 % See the DEA Tech Alerts and Changelog documentation:
 % https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/tech_alerts_changelog.html
 
-% How to update the 'DEA System Status':
+% How to update the 'System status of DEA':
 % Change the 'class' to either: tip / caution / danger
 % Default content: All DEA systems are working as expected. There are no outstanding incidents or errors to report.
 
-:::{admonition} DEA System Status
+:::{admonition} System status of DEA
 :class: caution
 
 * Performance issues with DEA Explorer and STAC API. See below.


### PR DESCRIPTION
<!-- Confirm each item by changing '[ ]' to '[x]' (if applicable). -->

* [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [ ] If required, update the [DEA Tech Alerts and Changelog](TechAlertsChangelog) and the [DEA Sandbox Updates banner](SandboxUpdatesBanner).

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml

* I also made the Markdown code slightly more readable by shifting some comments to the top.
* I moved both links to the intro paragraph at the top.
* I renamed the DEA Status Status banner to 'System status of DEA'