### PR TITLE
Added logic to prevent some layout components from displaying unless …

### DIFF
--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -1,12 +1,15 @@
 {% extends '!layout.html' %}
 
 {% block extrahead %}
+{%- if meta_keywords %}
 <meta name="keywords" content="{{ meta_keywords }}">
+{%- endif %}
 
 <script type="text/javascript" src="/_static/scripts/content-root.js"></script>
 <script type="text/javascript" src="/_static/scripts/custom-behaviour.js"></script>
 <script type="text/javascript" src="/_static/scripts/lightbox.js"></script>
 
+{%- if google_analytics_ga4_tag %}
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics_ga4_tag }}"></script>
 <script>
@@ -16,5 +19,6 @@
 
     gtag('config', '{{ google_analytics_ga4_tag }}');
 </script>
+{%- endif %}
 {% endblock %}
 


### PR DESCRIPTION
* The keywords header tag wont be used unless keywords exist
* The Google Analytics script wont be used unless the GA code exists