### PR TITLE
Followed standard format for editorconfig file with an asterisk secti…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,10 @@
 root = true
 
-[{ *.rst, *.md, *.yml, *.yaml }]
+[*]
 charset = utf-8
 end_of_line = lf
+
+[{ *.rst, *.md, *.yml, *.yaml }]
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space


### PR DESCRIPTION
…on at the top

Minor change. Moved this to the top of `.editorconfig` ...

```ini
[*]
charset = utf-8
end_of_line = lf
```