### PR TITLE
Update Knowledge Hub to point to updated THREDDS server URLs

### DIFF
--- a/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-intertidal-elevation-landsat-1.0.0/_data.yaml
@@ -58,7 +58,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=nidem/
     name: Access the data on AWS
-  - link: http://dapds00.nci.org.au/thredds/catalogs/fk4/nidem_1_0.html
+  - link: https://thredds.nci.org.au/thredds/catalog/catalogs/fk4/nidem_1_0.html
     name: Access the data on NCI
 
 code_examples: null

--- a/docs/data/product/australian-geographic-reference-image/_data.yaml
+++ b/docs/data/product/australian-geographic-reference-image/_data.yaml
@@ -49,7 +49,7 @@ maps: null
 explorers: null
 
 data:
-  - link: http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/agri/catalog.xml
+  - link: https://thredds.nci.org.au/thredds/catalog/fk4/agri/catalog.html
     name: Access the data on NCI
 
 code_examples: null

--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -52,7 +52,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls_fc_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls_fc_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=derivative/ga_ls_fc_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -65,11 +65,11 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=derivative
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls5t_nbart_gm_cyear_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls5t_nbart_gm_cyear_3/catalog.html
     name: Annual Landsat 5 observations on NCI
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls7e_nbart_gm_cyear_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls7e_nbart_gm_cyear_3/catalog.html
     name: Annual Landsat 7 observations on NCI
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls8c_nbart_gm_cyear_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls8c_nbart_gm_cyear_3/catalog.html
     name: Annual Landsat 8 observations on NCI
 
 code_examples: null

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -56,7 +56,7 @@ explorers:
     name: Low tide data explorer
 
 data:
-  - link: http://dapds00.nci.org.au/thredds/catalogs/fk4/hltc_2_0.html
+  - link: https://thredds.nci.org.au/thredds/catalog/catalogs/fk4/hltc_2_0.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -54,7 +54,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.html
+  - link: https://thredds.nci.org.au/thredds/catalog/catalogs/fk4/item_2_0.html
     name: Access the data on NCI
 
 code_examples: null

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -59,7 +59,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=derivative/ga_ls_mangrove_cover_cyear_3/3-0-0/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls_mangrove_cover_cyear_3/3-0-0/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls_mangrove_cover_cyear_3/3-0-0/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data in NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -57,7 +57,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2am_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -57,7 +57,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2bm_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://dapds00.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -58,7 +58,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2am_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -58,7 +58,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2bm_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -59,7 +59,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2am_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2am_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -59,7 +59,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_s2bm_ard_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/ka08/ga_s2bm_ard_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -55,7 +55,7 @@ explorers:
 data:
   - link: https://data.dea.ga.gov.au/?prefix=derivative/ga_ls_wo_3/
     name: Access the data on AWS
-  - link: https://dapds00.nci.org.au/thredds/catalog/jw04/ga_ls_wo_3/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls_wo_3/catalog.html
     name: Access the data on NCI
 
 code_examples:

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -52,7 +52,7 @@ maps: null
 explorers: null
 
 data:
-  - link: http://dapds00.nci.org.au/thredds/catalog/fk4/dlcd/2.1/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/fk4/dlcd/2.1/catalog.html
     name: Access the data on NCI
   - link: https://pid.geoscience.gov.au/dataset/ga/83868
     name: Download a zipped .tif

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -52,7 +52,7 @@ maps: null
 explorers: null
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/fk4/dlcd/2.1/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/fk4/dlcd/catalog.html
     name: Access the data on NCI
   - link: https://pid.geoscience.gov.au/dataset/ga/83868
     name: Download a zipped .tif

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -25,11 +25,11 @@ All new versions of our 'summary derivative products' will be affected by this c
 
 Learn more about the [DEA Summary Product Grid](/guides/reference/collection_3_summary_grid/).
 
-## 2024-05-30: NCI THREDDS data access links updated 
+## 2024-05-30: NCI THREDDS data access links updated to point to the new THREDDS server
 
-The NCI has released an upgrade to the THREDDS Data Service, and will [decommission the previous THREDDS server after 30th June 2024](https://opus.nci.org.au/display/NDP/THREDDS+Upgrade).
+NCI has released an upgrade to the THREDDS Data Service and will [decommission the existing THREDDS server after 30th June 2024](https://opus.nci.org.au/display/NDP/THREDDS+Upgrade).
 
-To prepare for this change, all THREDDS data access links have been updated from `https://dapds00.nci.org.au/thredds/...` to the new `https://thredds.nci.org.au/thredds/...` address.
+To prepare for this change, all THREDDS data access links in the Knowledge Hub have been updated to point to the new THREDDS server: all `https://dapds00.nci.org.au/thredds/...` links have been changed to `https://thredds.nci.org.au/thredds/...`.
 
 ## 2024-05-24: Misclassification issue with Sentinel-2 's2cloudless' cloud masking from 2022
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -25,6 +25,12 @@ All new versions of our 'summary derivative products' will be affected by this c
 
 Learn more about the [DEA Summary Product Grid](/guides/reference/collection_3_summary_grid/).
 
+## 2024-05-30: NCI THREDDS data access links updated 
+
+The NCI has released an upgrade to the THREDDS Data Service, and will [decommission the previous THREDDS server after 30th June 2024](https://opus.nci.org.au/display/NDP/THREDDS+Upgrade).
+
+To prepare for this change, all THREDDS data access links have been updated from `https://dapds00.nci.org.au/thredds/...` to the new `https://thredds.nci.org.au/thredds/...` address.
+
 ## 2024-05-24: Misclassification issue with Sentinel-2 's2cloudless' cloud masking from 2022
 
 An issue has been identified that is causing widespread misclassification of clouds in DEA's Sentinel-2 `s2cloudless` cloud mask data generated since January 2022. 


### PR DESCRIPTION
NCI is upgrading THREDDS, and deprecating the THREDDS links we currently point to in many of our products:
https://opus.nci.org.au/display/NDP/THREDDS+Upgrade

To ensure our data access links continue to work correctly, this PR updates THREDDS access links in the form:
https://dapds00.nci.org.au/thredds/catalog/catalogs/fx3/catalog.html

To:
https://thredds.nci.org.au/thredds/catalog/catalogs/fx3/catalog.html

I've done a spot check of a bunch of links, and all seem to be working correctly for me.

* [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [x] If required, update the [DEA Tech Alerts and Changelog][TechAlertsChangelog] and the [DEA Sandbox Updates banner][SandboxUpdatesBanner].

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml
