### PR TITLE
Capitalise Knowledge Hub on homepage

### DIFF
--- a/docs/_data.yaml
+++ b/docs/_data.yaml
@@ -1,5 +1,5 @@
 title: Welcome to the DEA Knowledge Hub
-description: The knowledge hub brings together information about Digital Earth Australia's products and services, allowing you to utilise our free and open-source satellite imagery archive.
+description: The Knowledge Hub brings together information about Digital Earth Australia's products and services, allowing you to utilise our free and open-source satellite imagery archive.
 
 product_themes:
   - name: Baseline satellite data


### PR DESCRIPTION
This may be a personal preference thing, but I feel "knowledge hub" should be capitalised on the homepage ("Knowledge Hub").

* [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [ ] If required, update the [DEA Tech Alerts and Changelog][TechAlertsChangelog] and the [DEA Sandbox Updates banner][SandboxUpdatesBanner].

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml
