### PR TITLE
Made the DEA Maps link more 'overt' in the guide

### DIFF
--- a/docs/guides/setup/dea_maps.rst
+++ b/docs/guides/setup/dea_maps.rst
@@ -3,9 +3,12 @@
 DEA Maps
 ========
 
-`Digital Earth Australia (DEA) Maps <https://maps.dea.ga.gov.au/>`_ is a website for interactive map-based access to DEA's products developed by `Data61 CSIRO`_ for `Geoscience Australia`_.
+Digital Earth Australia (DEA) Maps is a website for interactive map-based access to DEA's products developed by `Data61 CSIRO`_ for `Geoscience Australia`_. DEA Maps aims to provide easy access to DEA's products to help users to make more informed decisions.
 
-DEA Maps aims to provide easy access to DEA's products to help users to make more informed decisions.
+.. admonition:: Start exploring
+   :class: note
+
+   Open the `DEA Maps online platform <https://maps.dea.ga.gov.au/>`_.
 
 .. _Geoscience Australia: http://www.ga.gov.au/
 .. _Data61 CSIRO: https://data61.csiro.au/


### PR DESCRIPTION
The reason for this change is because the DEA Maps user guide shows up at the top of Google Search when you search "DEA Maps".

Therefore, I want to make the direct link to the DEA Maps platform more obvious when you first open the article.

![ksnip_20240606-165058](https://github.com/GeoscienceAustralia/dea-knowledge-hub/assets/144193171/7d1321fe-ccb2-4692-8aa2-57cc3374be7a)
