### PR TITLE
Removed the 'tab=overview' URL parameter

### DIFF
--- a/docs/_static/scripts/custom-behaviour.js
+++ b/docs/_static/scripts/custom-behaviour.js
@@ -115,9 +115,35 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 "tab"
             );
 
-            if (tabUrlParam) {
+            function addTabQueryParameter() {
+                window.history.pushState("", "", `?tab=${tabId}`);
+            }
+
+            function removeTabOverviewQueryParameter() {
+                let url = new URL(window.location.href);
+                let params = url.searchParams;
+                params.delete("tab");
+                // This conditional is needed to prevent a '?' at the end of the URL in the case where there are no URL parameters
+                if (params.size === 0) {
+                    window.history.pushState({}, "", url.pathname);
+                } else {
+                    window.history.pushState(
+                        {},
+                        "",
+                        `${url.pathname}?${params.toString()}`
+                    );
+                }
+            }
+
+            // Handle opening a URL with a 'tab' parameter
+
+            if (tabUrlParam === "overview") {
+                removeTabOverviewQueryParameter();
+            } else if (tabUrlParam) {
                 document.querySelector(`.sd-tab-set > #${tabUrlParam}`).click();
             }
+
+            // Handle clicking on a tab
 
             for (let i = 0; i < tabs.length; i++) {
                 let tab = tabs[i];
@@ -126,24 +152,12 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 if (tabId === "overview") {
                     // Don't add the 'tab' parameter for the Overview tab
                     tab.addEventListener("click", function () {
-                        let url = new URL(window.location.href);
-                        let params = url.searchParams;
-                        params.delete("tab");
-                        // This conditional is needed to prevent a '?' at the end of the URL in the case where there are no URL parameters
-                        if (params.size === 0) {
-                            window.history.pushState({}, "", url.pathname);
-                        } else {
-                            window.history.pushState(
-                                {},
-                                "",
-                                `${url.pathname}?${params.toString()}`
-                            );
-                        }
+                        removeTabOverviewQueryParameter();
                     });
                 } else if (tabId) {
                     // Add the 'tab' parameter for any other tab
                     tab.addEventListener("click", function () {
-                        window.history.pushState("", "", `?tab=${tabId}`);
+                        addTabQueryParameter();
                     });
                 }
             }

--- a/docs/_static/scripts/custom-behaviour.js
+++ b/docs/_static/scripts/custom-behaviour.js
@@ -114,15 +114,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
             let tabUrlParam = new URLSearchParams(window.location.search).get(
                 "tab"
             );
-            let overviewTabId = tabs[0].id;
 
-            if (!tabUrlParam) {
-                window.history.pushState(
-                    "",
-                    "",
-                    `?tab=${overviewTabId}${window.location.hash}`
-                );
-            } else {
+            if (tabUrlParam) {
                 document.querySelector(`.sd-tab-set > #${tabUrlParam}`).click();
             }
 
@@ -130,7 +123,22 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 let tab = tabs[i];
                 let tabId = tab.id;
 
-                if (tabId) {
+                if (tabId === "overview") {
+                    tab.addEventListener("click", function () {
+                        let url = new URL(window.location.href);
+                        let params = url.searchParams;
+                        params.delete("tab");
+                        if (params.size === 0) {
+                            window.history.pushState({}, "", url.pathname);
+                        } else {
+                            window.history.pushState(
+                                {},
+                                "",
+                                `${url.pathname}?${params.toString()}`
+                            );
+                        }
+                    });
+                } else if (tabId) {
                     tab.addEventListener("click", function () {
                         window.history.pushState("", "", `?tab=${tabId}`);
                     });

--- a/docs/_static/scripts/custom-behaviour.js
+++ b/docs/_static/scripts/custom-behaviour.js
@@ -106,7 +106,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         }
     })();
 
-    // Clicking on a product tab will add its tab ID to the URL. E.g. /example/?tab=overview
+    // Clicking on a product tab will add its tab ID to the URL. E.g. /example/?tab=details
 
     (function () {
         if (document.querySelector(".product-page")) {
@@ -124,10 +124,12 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 let tabId = tab.id;
 
                 if (tabId === "overview") {
+                    // Don't add the 'tab' parameter for the Overview tab
                     tab.addEventListener("click", function () {
                         let url = new URL(window.location.href);
                         let params = url.searchParams;
                         params.delete("tab");
+                        // This conditional is needed to prevent a '?' at the end of the URL in the case where there are no URL parameters
                         if (params.size === 0) {
                             window.history.pushState({}, "", url.pathname);
                         } else {
@@ -139,6 +141,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         }
                     });
                 } else if (tabId) {
+                    // Add the 'tab' parameter for any other tab
                     tab.addEventListener("click", function () {
                         window.history.pushState("", "", `?tab=${tabId}`);
                     });

--- a/docs/_static/scripts/custom-behaviour.js
+++ b/docs/_static/scripts/custom-behaviour.js
@@ -115,7 +115,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 "tab"
             );
 
-            function addTabQueryParameter() {
+            function addTabQueryParameter(tabId) {
                 window.history.pushState("", "", `?tab=${tabId}`);
             }
 
@@ -157,7 +157,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 } else if (tabId) {
                     // Add the 'tab' parameter for any other tab
                     tab.addEventListener("click", function () {
-                        addTabQueryParameter();
+                        addTabQueryParameter(tabId);
                     });
                 }
             }


### PR DESCRIPTION
The tab=overview URL parameter no longer displays when the Overview tab is selected on product pages. This is to make the URLs shorter, nicer, and more easily shared.

Before: https://pr-255-preview.khpreview.dea.ga.gov.au/data/product/dea-coastlines/?tab=overview

After: https://pr-255-preview.khpreview.dea.ga.gov.au/data/product/dea-coastlines/

To test this, open up a product page and click through the tabs: https://pr-255-preview.khpreview.dea.ga.gov.au/data/product/dea-coastlines/