### PR TITLE
Updated to use the new Subscribe link for the DEA newsletter

### DIFF
--- a/docs/_templates/home-v1.rst
+++ b/docs/_templates/home-v1.rst
@@ -102,7 +102,7 @@
 
       `Visit the DEA website <https://www.dea.ga.gov.au/>`_
 
-      `Subscribe to our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_
+      `Subscribe to our newsletter <https://communication.ga.gov.au/dea-news-subscribe>`_
 
    .. container::
 

--- a/docs/data/product/dea-fractional-cover-landsat/_overview_1.md
+++ b/docs/data/product/dea-fractional-cover-landsat/_overview_1.md
@@ -5,6 +5,6 @@ Digital Earth Australia (DEA) Fractional Cover splits landscape observation data
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_overview_1.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_overview_1.md
@@ -5,6 +5,6 @@ This product is designed to make it easier to analyse and interpret fractional c
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_overview_1.md
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_overview_1.md
@@ -5,6 +5,6 @@ The DEA Geometric Median and Median Absolute Deviation products use statistical 
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-intertidal-extents-landsat/_overview_1.md
+++ b/docs/data/product/dea-intertidal-extents-landsat/_overview_1.md
@@ -7,6 +7,6 @@ The dataset provides information on the lowest (LOT) and highest (HOT) observed 
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed as part of the [DEA Intertidal](/data/product/dea-intertidal/) product suite. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed as part of the [DEA Intertidal](/data/product/dea-intertidal/) product suite. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-land-cover-landsat/_overview_1.md
+++ b/docs/data/product/dea-land-cover-landsat/_overview_1.md
@@ -5,6 +5,6 @@ Digital Earth Australia (DEA) Land Cover translates over 30 years of satellite i
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-water-observations-landsat/_overview_1.md
+++ b/docs/data/product/dea-water-observations-landsat/_overview_1.md
@@ -5,6 +5,6 @@ Digital Earth Australia (DEA) Water Observations uses an algorithm to classify e
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/data/product/dea-water-observations-statistics-landsat/_overview_1.md
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_overview_1.md
@@ -5,6 +5,6 @@ Digital Earth Australia (DEA) Water Observations uses an algorithm to classify e
 :::{admonition} New version in development
 :class: note
 
-A new version of this product is being developed. Subscribe to the [DEA newsletter](https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive) to be notified of product releases.
+A new version of this product is being developed. Subscribe to the [DEA newsletter](https://communication.ga.gov.au/dea-news-subscribe) to be notified of product releases.
 :::
 

--- a/docs/tech-alerts-changelog/_data.yaml
+++ b/docs/tech-alerts-changelog/_data.yaml
@@ -1,3 +1,3 @@
 title: DEA Tech Alerts and Changelog
-description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur. To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_. And, to stay informed of the latest updates, `subscribe to our newsletter <https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive>`_.
+description: Find out about the latest updates to Digital Earth Australia's products and services, planned maintenance, and any outages that may occur. To check the current status of DEA's services, see the `DEA monitoring dashboard <https://monitoring.dea.ga.gov.au/>`_. And, to stay informed of the latest updates, `subscribe to our newsletter <https://communication.ga.gov.au/dea-news-subscribe>`_.
 


### PR DESCRIPTION
The current link doesn't work anymore (it died) therefore, so I updated to use the new link.

Old: https://www.dea.ga.gov.au/news/dea-newsletter-and-communications-archive

New: https://communication.ga.gov.au/dea-news-subscribe
