### PR TITLE
Standardising date formats on product pages

### DIFF
--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -12,7 +12,7 @@ latest_version_link: null
 product_type: Derivative
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
+  start: 16 Aug 1986
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-hotspots/_data.yaml
+++ b/docs/data/product/dea-hotspots/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Data service
 spatial_data_type: Vector
 time_span:
-  start: 27/08/2002
+  start: 27 Aug 2002
   end: Present
 update_frequency: Every 10 minutes
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
-  end: 17/11/2011
+  start: 16 Aug 1986
+  end: 17 Nov 2011
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 28/05/1999
-  end: 06/04/2022
+  start: 28 May 1999
+  end: 6 Apr 2022
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 19/03/2013
+  start: 19 Mar 2013
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 31/10/2021
+  start: 31 Oct 2021
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
-  end: 17/11/2011
+  start: 16 Aug 1986
+  end: 17 Nov 2011
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 28/05/1999
-  end: 06/04/2022
+  start: 28 May 1999
+  end: 6 Apr 2022
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 19/03/2013
+  start: 19 Mar 2013
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 31/10/2021
+  start: 31 Oct 2021
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
-  end: 17/11/2011
+  start: 16 Aug 1986
+  end: 17 Nov 2011
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 28/05/1999
-  end: 06/04/2022
+  start: 28 May 1999
+  end: 6 Apr 2022
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 19/03/2013
+  start: 19 Mar 2013
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 31/10/2021
+  start: 31 Oct 2021
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 12/07/2015
+  start: 12 Jul 2015
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 30/06/2017
+  start: 30 Jun 2017
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
-  end: 17/11/2011
+  start: 16 Aug 1986
+  end: 17 Nov 2011
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -13,8 +13,8 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 28/05/1999
-  end: 06/04/2022
+  start: 28 May 1999
+  end: 6 Apr 2022
 update_frequency: Daily
 next_update: null
 product_ids:

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 19/03/2013
+  start: 19 Mar 2013
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 31/10/2021
+  start: 31 Oct 2021
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 12/07/2015
+  start: 12 Jul 2015
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 30/06/2017
+  start: 30 Jun 2017
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 12/07/2015
+  start: 12 Jul 2015
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Baseline
 spatial_data_type: Raster
 time_span:
-  start: 30/06/2017
+  start: 30 Jun 2017
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: false
 product_type: Derivative
 spatial_data_type: Raster
 time_span:
-  start: 16/08/1986
+  start: 16 Aug 1986
   end: Present
 update_frequency: Daily
 next_update: null

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -13,7 +13,7 @@ is_provisional: true
 product_type: Derivative
 spatial_data_type: Raster
 time_span:
-  start: 14/03/2023
+  start: 14 Mar 2023
   end: Present
 update_frequency: Daily
 next_update: null


### PR DESCRIPTION
On product pages, I changed several dates from the format `1/1/2024` to the format `1 Jan 2024`.

This is to make the dates more easily readable and also to avoid confusion since in the US, they write the month number first in this  `1/1/2024` date format.

I double checked I converted all the dates correctly, since this change involved potential for human error.