### PR TITLE
Added a link to the PR Preview comment (from the Github Action)

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -47,6 +47,10 @@ jobs:
 
             <table> <!-- #pr-preview-comment -->
                 <tr>
+                    <td><strong>Preview site:</strong></td>
+                    <td>Not deployed yet (<a href="https://${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au/">PR Preview ${{github.event.pull_request.number}}</a>)</td>
+                </tr>
+                <tr>
                     <td><strong>Deploy log:</strong></td>
                     <td><a href="${{ env.PR_PREVIEW_DEPLOY_LOG_URL }}">View the deploy log</a></td>
                 </tr>

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -48,7 +48,7 @@ jobs:
             <table> <!-- #pr-preview-comment -->
                 <tr>
                     <td><strong>Preview site:</strong></td>
-                    <td>Not deployed yet (<a href="https://${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au/">PR Preview ${{github.event.pull_request.number}}</a>)</td>
+                    <td>Not deployed yet (<a href="https://${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au/" style="color: DarkOrange;">PR Preview ${{github.event.pull_request.number}}</a>)</td>
                 </tr>
                 <tr>
                     <td><strong>Deploy log:</strong></td>

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -105,7 +105,7 @@ jobs:
             <table> <!-- #pr-preview-comment -->
                 <tr>
                     <td><strong>Preview site:</strong></td>
-                    <td><a href="https://${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au/">${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au</a></td>
+                    <td><a href="https://${{ env.PR_PREVIEW_SUBDOMAIN }}.khpreview.dea.ga.gov.au/">PR Preview ${{github.event.pull_request.number}}</a></td>
                 </tr>
                 <tr>
                     <td><strong>Deploy log:</strong></td>


### PR DESCRIPTION
**Reason for this change:** When the PR Preview is rebuilding, the link disappeared.

**The solution:** Add the link to the 'PR Preview is deploying' comment.