### PR TITLE
Renamed the 'publish notebooks to knowledge hub' github event for readability

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -3,7 +3,7 @@ name: Deploy to Production
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [republish-docs] # Triggered by the dea-notebooks repo - https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/.github/workflows/trigger_docs.yaml
+    types: [publish-notebooks-to-knowledge-hub] # Triggered by the dea-notebooks repository: https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/.github/workflows/trigger_docs.yaml
   push:
     branches: [main]
 


### PR DESCRIPTION
Minor change. This PR aligns with a PR on the dea-notebooks repo: https://github.com/GeoscienceAustralia/dea-notebooks/pull/1253