### PR TITLE
Updated all ODC Slack links to the new ODC Discord link

### DIFF
--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -15,7 +15,7 @@
                 <li><a href="/guides/about/glossary/">Glossary</a></li>
                 <li><a href="https://www.dea.ga.gov.au/contact">Contact us</a></li>
                 <li><a href="https://gis.stackexchange.com/questions/tagged/open-data-cube">ODC Stack Exchange</a></li>
-                <li><a href="http://slack.opendatacube.org/">ODC Slack</a></li>
+                <li><a href="https://discord.com/invite/4hhBQVas5U">ODC Discord Chat</a></li>
             </ul>
         </div>
         <div class="col-12 col-md-6">

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -15,7 +15,7 @@
                 <li><a href="/guides/about/glossary/">Glossary</a></li>
                 <li><a href="https://www.dea.ga.gov.au/contact">Contact us</a></li>
                 <li><a href="https://gis.stackexchange.com/questions/tagged/open-data-cube">ODC Stack Exchange</a></li>
-                <li><a href="https://discord.com/invite/4hhBQVas5U">ODC Discord Chat</a></li>
+                <li><a href="https://discord.com/invite/4hhBQVas5U">ODC Discord chat</a></li>
             </ul>
         </div>
         <div class="col-12 col-md-6">

--- a/docs/guides/setup/README.rst
+++ b/docs/guides/setup/README.rst
@@ -41,7 +41,7 @@ Getting help
 You can ask questions (and view previously asked questions) on the `Open Data Cube Stack Exchange`_ page.
 When asking a question, tag it with ``open-data-cube``.
 
-You can also `join our Slack community`_ for help setting up or using Digital Earth Australia.
+You can also join our `Open Data Cube Discord Chat`_ for help setting up or using Digital Earth Australia.
 
 .. _Open Data Cube Stack Exchange: https://gis.stackexchange.com/questions/tagged/open-data-cube
-.. _join our Slack community: http://slack.opendatacube.org/
+.. _Open Data Cube Discord Chat: https://discord.com/invite/4hhBQVas5U

--- a/docs/guides/setup/README.rst
+++ b/docs/guides/setup/README.rst
@@ -41,7 +41,7 @@ Getting help
 You can ask questions (and view previously asked questions) on the `Open Data Cube Stack Exchange`_ page.
 When asking a question, tag it with ``open-data-cube``.
 
-You can also join our `Open Data Cube Discord Chat`_ for help setting up or using Digital Earth Australia.
+You can also join our `Open Data Cube Discord chat`_ for help setting up or using Digital Earth Australia.
 
 .. _Open Data Cube Stack Exchange: https://gis.stackexchange.com/questions/tagged/open-data-cube
-.. _Open Data Cube Discord Chat: https://discord.com/invite/4hhBQVas5U
+.. _Open Data Cube Discord chat: https://discord.com/invite/4hhBQVas5U

--- a/docs/guides/setup/Sandbox/sandbox.rst
+++ b/docs/guides/setup/Sandbox/sandbox.rst
@@ -117,10 +117,10 @@ Where can I get help?
 You can ask questions (and view previously asked questions) on the `Open Data Cube Stack Exchange`_ page.
 When asking a question, tag it with `open-data-cube`.
 
-You can also `join our Slack community`_ for help setting up or using Digital Earth Australia.
+You can also join our `Open Data Cube Discord Chat`_ for help setting up or using Digital Earth Australia.
 
 .. _Open Data Cube Stack Exchange: https://gis.stackexchange.com/questions/tagged/open-data-cube
-.. _join our Slack community: http://slack.opendatacube.org/
+.. _Open Data Cube Discord Chat: https://discord.com/invite/4hhBQVas5U
 
 DEA Sandbox disclaimer
 ----------------------

--- a/docs/guides/setup/Sandbox/sandbox.rst
+++ b/docs/guides/setup/Sandbox/sandbox.rst
@@ -117,10 +117,10 @@ Where can I get help?
 You can ask questions (and view previously asked questions) on the `Open Data Cube Stack Exchange`_ page.
 When asking a question, tag it with `open-data-cube`.
 
-You can also join our `Open Data Cube Discord Chat`_ for help setting up or using Digital Earth Australia.
+You can also join our `Open Data Cube Discord chat`_ for help setting up or using Digital Earth Australia.
 
 .. _Open Data Cube Stack Exchange: https://gis.stackexchange.com/questions/tagged/open-data-cube
-.. _Open Data Cube Discord Chat: https://discord.com/invite/4hhBQVas5U
+.. _Open Data Cube Discord chat: https://discord.com/invite/4hhBQVas5U
 
 DEA Sandbox disclaimer
 ----------------------


### PR DESCRIPTION
The ODC Slack is being deprecated in favour of the ODC Discord, so we are updating all our links across all platforms.