### PR TITLE
Add NCI access to Intertidal, update NCI projects

### DIFF
--- a/docs/data/product/dea-intertidal/_data.yaml
+++ b/docs/data/product/dea-intertidal/_data.yaml
@@ -64,6 +64,8 @@ data:
     name: Access the data on AWS
   - link: https://elevation.fsdf.org.au/
     name: Download the data from ELVIS
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_s2ls_intertidal_cyear_3/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Intertidal/

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -69,10 +69,10 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
      - Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 3)
      
    * - jw04_
-     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. DEA Water Observations, DEA Fractional Cover, DEA GeoMAD, DEA Intertidal
+     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. `Water Observations </data/product/dea-water-observations-landsat/>`_, `Fractional Cover </data/product/dea-fractional-cover-landsat/>`_, `GeoMAD </data/product/dea-geometric-median-and-median-absolute-deviation-landsat/>`_, `Mangroves </data/product/dea-mangrove-canopy-cover-landsat/>`_, and `Intertidal </data/product/dea-intertidal/>`_.
 
    * - fk4_
-     - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC
+     - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. `Intertidal Elevation (NIDEM) </data/old-version/dea-intertidal-elevation-landsat-1.0.0/>`_, `Intertidal Extents (ITEM) </data/product/dea-intertidal-extents-landsat/>`_, and `High and Low Tide Imagery (HLTC) </data/product/dea-high-and-low-tide-imagery-landsat/>`_.
 
 .. _xu18: https://my.nci.org.au/mancini/project/xu18
 .. _ka08: https://my.nci.org.au/mancini/project/ka08

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -62,6 +62,9 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
    * - Project
      - Contents
 
+   * - v10_
+     - Provides access to DEA NCI module and ancillary data
+
    * - xu18_
      - Geoscience Australia Landsat Analysis Ready Data (Collection 3)
  
@@ -69,19 +72,13 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
      - Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 3)
      
    * - jw04_
-     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. WO, FC
+     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. WO, FC, Intertidal
 
    * - fk4_
      - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC
- 
-   * - if87_
-     - Legacy Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 1)
-     
-.. _wd8: https://my.nci.org.au/mancini/project/wd8
+
+.. _xu18: https://my.nci.org.au/mancini/project/v10     
 .. _xu18: https://my.nci.org.au/mancini/project/xu18
-.. _if87: https://my.nci.org.au/mancini/project/if87
+.. _ka08: https://my.nci.org.au/mancini/project/ka08
 .. _jw04: https://my.nci.org.au/mancini/project/jw04
 .. _fk4: https://my.nci.org.au/mancini/project/fk4
-.. _rs0: https://my.nci.org.au/mancini/project/rs0
-.. _ka08: https://my.nci.org.au/mancini/project/ka08
-

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -69,7 +69,7 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
      - Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 3)
      
    * - jw04_
-     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. WO, FC, GeoMAD, Intertidal
+     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. DEA Water Observations, DEA Fractional Cover, DEA GeoMAD, DEA Intertidal
 
    * - fk4_
      - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -51,7 +51,7 @@ commercial entities contact the  `DEA Helpdesk`_ to help determine requirements.
 Data Access
 ===========
 
-DEA Data is stored on several "GData filesystems" on the NCI. To access the data you 
+DEA Data is stored on several "g/data" filesystems on the NCI. To access the data you 
 need to request access to one or more of the **Projects** listed below.
 
 Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project memberships.
@@ -61,9 +61,6 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
 
    * - Project
      - Contents
-
-   * - v10_
-     - Provides access to DEA NCI module and ancillary data
 
    * - xu18_
      - Geoscience Australia Landsat Analysis Ready Data (Collection 3)
@@ -77,7 +74,6 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
    * - fk4_
      - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC
 
-.. _v10: https://my.nci.org.au/mancini/project/v10     
 .. _xu18: https://my.nci.org.au/mancini/project/xu18
 .. _ka08: https://my.nci.org.au/mancini/project/ka08
 .. _jw04: https://my.nci.org.au/mancini/project/jw04

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -72,7 +72,7 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
      - Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 3)
      
    * - jw04_
-     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. WO, FC, Intertidal
+     - Geoscience Australia Landsat Derivatives (Collection 3), e.g. WO, FC, GeoMAD, Intertidal
 
    * - fk4_
      - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC

--- a/docs/guides/setup/NCI/account.rst
+++ b/docs/guides/setup/NCI/account.rst
@@ -77,7 +77,7 @@ Use `MyNCI <https://my.nci.org.au/>`_ to view and manage your project membership
    * - fk4_
      - Legacy Geoscience Australia Landsat Derivatives (Collection 2), e.g. NIDEM, ITEM, HLTC
 
-.. _xu18: https://my.nci.org.au/mancini/project/v10     
+.. _v10: https://my.nci.org.au/mancini/project/v10     
 .. _xu18: https://my.nci.org.au/mancini/project/xu18
 .. _ka08: https://my.nci.org.au/mancini/project/ka08
 .. _jw04: https://my.nci.org.au/mancini/project/jw04


### PR DESCRIPTION
- Adds NCI access to DEA Intertidal
- Removes defunct if87 Legacy Geoscience Australia Sentinel-2 Analysis Ready Data (Collection 1) NCI project
- Minor clarifications on NCI page

* [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [ ] If required, update the [DEA Tech Alerts and Changelog][TechAlertsChangelog] and the [DEA Sandbox Updates banner][SandboxUpdatesBanner].

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml
