### PR TITLE
Deleted the AWS access link on the ARD NBAR pages

### DIFF
--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -55,8 +55,6 @@ explorers:
 data:
   - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
-  - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
-    name: Access the data on AWS
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -55,8 +55,6 @@ explorers:
 data:
   - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data in NCI
-  - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
-    name: Access the data on AWS
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -55,8 +55,6 @@ explorers:
 data:
   - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
-  - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
-    name: Access the data on AWS
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -59,8 +59,6 @@ explorers:
 data:
   - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
     name: Access the data on NCI
-  - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
-    name: Access the data on AWS
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/


### PR DESCRIPTION
Lien noticed that on AWS, the Surface Reflectance data doesn't include NBAR data; whereas, on NCI it includes NBAR data. She thinks it is because the NBAR data is filtered out from the AWS.

Therefore, I removed the AWS access link on all NBAR product pages.

Here are some comparisons to demonstrate how NBAR data is excluded on AWS:

* LS5
  * NCI: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/093/076/1990/07/29/catalog.html
  * AWS: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/093/076/1990/07/29/
* LS9
  * NCI: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls9c_ard_3/102/071/2023/08/01/catalog.html
  * AWS: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/102/071/2023/08/01/
