### PR TITLE
For ARD products, linked NCI to the correct subfolder

### DIFF
--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls7e_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls8c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls9c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls7e_ard_3/catalog.html
     name: Access the data in NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls8c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls9c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls7e_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls8c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls9c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls7e_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -53,7 +53,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls8c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -57,7 +57,7 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls9c_ard_3/catalog.html
     name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS


### PR DESCRIPTION
Updated NCI links for ARD L5, L7, L8, and L9 to point to the relevant subfolder instead of the root folder.

E.g.

* Before: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
* After: https://thredds.nci.org.au/thredds/catalog/xu18/ga_ls5t_ard_3/catalog.html