### PR TITLE
Standardised AWS before NCI access link

### DIFF
--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -52,10 +52,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls_fc_3/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=derivative/ga_ls_fc_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_ls_fc_3/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Fractional_Cover/

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -57,10 +57,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data in NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data in NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -57,10 +57,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -57,10 +57,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls5t_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls7e_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -53,10 +53,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls8c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -57,10 +57,10 @@ explorers:
     name: Data explorer
 
 data:
-  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
-    name: Access the data on NCI
   - link: https://data.dea.ga.gov.au/?prefix=baseline/ga_ls9c_ard_3/
     name: Access the data on AWS
+  - link: https://thredds.nci.org.au/thredds/catalog/xu18/catalog.html
+    name: Access the data on NCI
 
 code_examples:
   - link: /notebooks/DEA_products/DEA_Landsat_Surface_Reflectance/


### PR DESCRIPTION
For consistency, ordered the AWS access link before the NCI one on all active product pages.