### PR TITLE
Tech alerts page - Removed duplicates and fixed ordering

### DIFF
--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -68,26 +68,6 @@ Learn more about how to [understand and analyse this report](/guides/setup/opera
 
 Internal staff can also [view the full history of data](https://mgmt.sandbox.dea.ga.gov.au/d/c1674b20-8c8a-4d90-aef2-02796275cf2b/4e57919d-fc9d-59d7-9bd1-aa61d41bcb92?orgId=1).
 
-## 1 Jul 2024: External data products now featured on the Knowledge Hub
-
-External data products are produced by external providers such as a different program of Geoscience Australia or a different organisation entirely. These external data products may assist with the analysis of DEA data. DEA even provides services relating to some of these external products. Therefore, we have begun to include some external products on our Knowledge Hub so that you can easily find and access this data. So far, we have added three external data products to the Knowledge Hub. But watch this space, as there are more to come!
-
-View the [External data products in the Knowledge Hub](/data/theme/external-data/).
-
-## 1 Jul 2024: DEA Sandbox new user signups restored
-
-An issue was preventing new users from signing up to the [DEA Sandbox](https://app.sandbox.dea.ga.gov.au/) for the past 5 days. We have now fixed the issue and you should now be able to sign up for the DEA Sandbox.
-
-## 28 Jun 2024: DEA Published Product Currency Report released
-
-We have released a report that tracks the Currency of our data products and if they are on time. Currency is a measure of how consistently DEA’s data products have been published through DEA in line with the stated update frequency on or before the scheduled publish date. External auditors can use this report to verify that DEA is meeting its performance targets, and internally, we use it for our annual reporting practices.
-
-View the [DEA Published Product Currency Report](https://mgmt.sandbox.dea.ga.gov.au/public-dashboards/d22241dbfca54b1fa9f73938ef26e645?orgId=1).
-
-Learn more about how to [understand and analyse this report](/guides/setup/operational-reports/product-currency-report/).
-
-Internal staff can also [view the full history of data](https://mgmt.sandbox.dea.ga.gov.au/d/c1674b20-8c8a-4d90-aef2-02796275cf2b/4e57919d-fc9d-59d7-9bd1-aa61d41bcb92?orgId=1).
-
 ## 1 Aug 2024: Resolved outage of Hotspots S-NPP VIIRS data
 
 The Suomi-NPP VIIRS Hotspots sub-product has resumed publishing data because the satellite's issue has been resolved.
@@ -95,26 +75,6 @@ The Suomi-NPP VIIRS Hotspots sub-product has resumed publishing data because the
 ## 25 Jul 2024: Outage of Hotspots S-NPP VIIRS data (Resolved)
 
 This issue concerns [DEA Hotspots](https://knowledge.dea.ga.gov.au/data/product/dea-hotspots/). The Suomi-NPP satellite has experienced a data outage that has resulted in data unavailability until further notice. Therefore, Suomi-NPP VIIRS Hotspots cannot be published until this issue is resolved. Other DEA Hotspots sub-products are unaffected by this outage.
-
-## 1 Jul 2024: External data products now featured on the Knowledge Hub
-
-External data products are produced by external providers such as a different program of Geoscience Australia or a different organisation entirely. These external data products may assist with the analysis of DEA data. DEA even provides services relating to some of these external products. Therefore, we have begun to include some external products on our Knowledge Hub so that you can easily find and access this data. So far, we have added three external data products to the Knowledge Hub. But watch this space, as there are more to come!
-
-View the [External data products in the Knowledge Hub](/data/theme/external-data/).
-
-## 1 Jul 2024: DEA Sandbox new user signups restored
-
-An issue was preventing new users from signing up to the [DEA Sandbox](https://app.sandbox.dea.ga.gov.au/) for the past 5 days. We have now fixed the issue and you should now be able to sign up for the DEA Sandbox.
-
-## 28 Jun 2024: DEA Published Product Currency Report released
-
-We have released a report that tracks the Currency of our data products and if they are on time. Currency is a measure of how consistently DEA’s data products have been published through DEA in line with the stated update frequency on or before the scheduled publish date. External auditors can use this report to verify that DEA is meeting its performance targets, and internally, we use it for our annual reporting practices.
-
-View the [DEA Published Product Currency Report](https://mgmt.sandbox.dea.ga.gov.au/public-dashboards/d22241dbfca54b1fa9f73938ef26e645?orgId=1).
-
-Learn more about how to [understand and analyse this report](/guides/setup/operational-reports/product-currency-report/).
-
-Internal staff can also [view the full history of data](https://mgmt.sandbox.dea.ga.gov.au/d/c1674b20-8c8a-4d90-aef2-02796275cf2b/4e57919d-fc9d-59d7-9bd1-aa61d41bcb92?orgId=1).
 
 ## 24 Jun 2024: Performance issues with DEA Explorer and STAC API (Resolved)
 

--- a/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+++ b/docs/tech-alerts-changelog/_tech_alerts_changelog.md
@@ -48,6 +48,14 @@ The newly released version 4.0.0 of [DEA Geometric Median and Median Absolute De
 
 See the [Version 4.0.0 Changelog](/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/?tab=history) for more information.
 
+## 1 Aug 2024: Resolved outage of Hotspots S-NPP VIIRS data
+
+The Suomi-NPP VIIRS Hotspots sub-product has resumed publishing data because the satellite's issue has been resolved.
+
+## 25 Jul 2024: Outage of Hotspots S-NPP VIIRS data (Resolved)
+
+This issue concerns [DEA Hotspots](https://knowledge.dea.ga.gov.au/data/product/dea-hotspots/). The Suomi-NPP satellite has experienced a data outage that has resulted in data unavailability until further notice. Therefore, Suomi-NPP VIIRS Hotspots cannot be published until this issue is resolved. Other DEA Hotspots sub-products are unaffected by this outage.
+
 ## 1 Jul 2024: External data products now featured on the Knowledge Hub
 
 External data products are produced by external providers such as a different program of Geoscience Australia or a different organisation entirely. These external data products may assist with the analysis of DEA data. DEA even provides services relating to some of these external products. Therefore, we have begun to include some external products on our Knowledge Hub so that you can easily find and access this data. So far, we have added three external data products to the Knowledge Hub. But watch this space, as there are more to come!
@@ -67,14 +75,6 @@ View the [DEA Published Product Currency Report](https://mgmt.sandbox.dea.ga.gov
 Learn more about how to [understand and analyse this report](/guides/setup/operational-reports/product-currency-report/).
 
 Internal staff can also [view the full history of data](https://mgmt.sandbox.dea.ga.gov.au/d/c1674b20-8c8a-4d90-aef2-02796275cf2b/4e57919d-fc9d-59d7-9bd1-aa61d41bcb92?orgId=1).
-
-## 1 Aug 2024: Resolved outage of Hotspots S-NPP VIIRS data
-
-The Suomi-NPP VIIRS Hotspots sub-product has resumed publishing data because the satellite's issue has been resolved.
-
-## 25 Jul 2024: Outage of Hotspots S-NPP VIIRS data (Resolved)
-
-This issue concerns [DEA Hotspots](https://knowledge.dea.ga.gov.au/data/product/dea-hotspots/). The Suomi-NPP satellite has experienced a data outage that has resulted in data unavailability until further notice. Therefore, Suomi-NPP VIIRS Hotspots cannot be published until this issue is resolved. Other DEA Hotspots sub-products are unaffected by this outage.
 
 ## 24 Jun 2024: Performance issues with DEA Explorer and STAC API (Resolved)
 

--- a/docs/tech-alerts-changelog/previous-years/2023.md
+++ b/docs/tech-alerts-changelog/previous-years/2023.md
@@ -18,6 +18,7 @@ In addition, this update includes 14 new and updated Jupyter notebooks. See [ver
 ## 11 Aug 2023: Small systems updates
 
 Technical DEA internals which have changed in the last week.
+
 * Some tweaks to DEA Sandbox DNS resolution last Friday.
 * The URL [https://explorer.dea.ga.gov.au/](https://explorer.dea.ga.gov.au/) will be changed to show data in the DEA AWS data holdings instead of the NCI holdings.
 * Some data gap filling of Landsat 8 ARD, Landsat 8 FC and Landsat 8 WO for 2023.

--- a/docs/tech-alerts-changelog/previous-years/2023.md
+++ b/docs/tech-alerts-changelog/previous-years/2023.md
@@ -3,14 +3,6 @@
 :::{include} ./_components/previous-years-introduction.md
 :::
 
-## 11 Aug 2023: Small systems updates
-
-Technical DEA internals which have changed in the last week.
-* Some tweaks to DEA Sandbox DNS resolution last Friday.
-* The URL [https://explorer.dea.ga.gov.au/](https://explorer.dea.ga.gov.au/) will be changed to show data in the DEA AWS data holdings instead of the NCI holdings.
-* Some data gap filling of Landsat 8 ARD, Landsat 8 FC and Landsat 8 WO for 2023.
-* Reduced the delay between Sentinel 2 ARD data being produced (on the NCI), and being delivered to AWS. It was *up to 48 hours* and should now be *up to 24 hours*.
-
 ## Nov 2023: Release of version 0.3.0 of DEA Tools
 
 Major update to the [DEA Tools Python package](https://knowledge.dea.ga.gov.au/notebooks/Tools/), including new tools for:
@@ -22,6 +14,14 @@ Major update to the [DEA Tools Python package](https://knowledge.dea.ga.gov.au/n
 * [spatial operations](https://knowledge.dea.ga.gov.au/notebooks/Tools/gen/dea_tools.spatial.html)
 
 In addition, this update includes 14 new and updated Jupyter notebooks. See [version 0.3.0 release notes](https://github.com/GeoscienceAustralia/dea-notebooks/releases/tag/0.3.0) for more detail.
+
+## 11 Aug 2023: Small systems updates
+
+Technical DEA internals which have changed in the last week.
+* Some tweaks to DEA Sandbox DNS resolution last Friday.
+* The URL [https://explorer.dea.ga.gov.au/](https://explorer.dea.ga.gov.au/) will be changed to show data in the DEA AWS data holdings instead of the NCI holdings.
+* Some data gap filling of Landsat 8 ARD, Landsat 8 FC and Landsat 8 WO for 2023.
+* Reduced the delay between Sentinel 2 ARD data being produced (on the NCI), and being delivered to AWS. It was *up to 48 hours* and should now be *up to 24 hours*.
 
 ## Aug 2023: New notebooks, features and documentation
 


### PR DESCRIPTION
On the tech alerts page, there were some duplicated tech alerts and also some tech alerts was not in the correct order (they're meant to be ordered by date). This PR fixes these issues.