### PR TITLE
Fix for styling issue where search match was displaying on new line

### DIFF
--- a/docs/_static/styles/components/_rubric.scss
+++ b/docs/_static/styles/components/_rubric.scss
@@ -1,4 +1,6 @@
 p.rubric {
+    display: block !important;
+
     &.h2 {}
 
     &.h3 {


### PR DESCRIPTION
Steps to replicate:

1. Search for 'intertidal' using the site's search bar
2. Click on 'DEA Intertidal'
3. The header on the page will have an unwanted linebreak between 'DEA' and 'Intertidal'

Applied a fix to the CSS stylesheet.