### PR TITLE
Added code comments to the redirects files

### DIFF
--- a/docs/_redirects/cmi-data-products.txt
+++ b/docs/_redirects/cmi-data-products.txt
@@ -1,5 +1,7 @@
 # CMI Data Product redirects
 
+# Redirects from the old CMI product page URLs to the new Knowledge Hub website. Each product page had multiple URL aliases which are also redirected.
+
 node/818                                                                      data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data-products/dea/818/dea-surface-reflectance-oa-landsat-9                    data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data-products/dea/818/clone-of-dea-surface-reflectance-oa-landsat-8-oli-tirs  data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs

--- a/docs/_redirects/cmi-data-products.txt
+++ b/docs/_redirects/cmi-data-products.txt
@@ -1,6 +1,6 @@
 # CMI Data Product redirects
 
-# Redirects from the old CMI product page URLs to the new Knowledge Hub website. Each product page had multiple URL aliases which are also redirected.
+# Redirects from product pages on the old CMI site to the new Knowledge Hub. Each product page had multiple URL aliases which are also redirected.
 
 node/818                                                                      data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data-products/dea/818/dea-surface-reflectance-oa-landsat-9                    data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs

--- a/docs/_redirects/cmi-old-versions.txt
+++ b/docs/_redirects/cmi-old-versions.txt
@@ -1,5 +1,7 @@
 # CMI old product version redirects
 
+# Redirects from the old CMI product page URLs to the new Knowledge Hub website. Each product page had multiple URL aliases which are also redirected. These are product pages for old versions; i.e. they are not the latest product versions.
+
 node/111                                                              data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0
 data-products/dea/111/dea-surface-reflectance-nbar-landsat-deprecated data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0
 sr-n_25_2.0.0                                                         data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0

--- a/docs/_redirects/cmi-old-versions.txt
+++ b/docs/_redirects/cmi-old-versions.txt
@@ -1,6 +1,6 @@
 # CMI old product version redirects
 
-# Redirects from the old CMI product page URLs to the new Knowledge Hub website. Each product page had multiple URL aliases which are also redirected. These are product pages for old versions; i.e. they are not the latest product versions.
+# Redirects from 'old version' product pages on the old CMI site to the new Knowledge Hub. Each product page had multiple URL aliases which are also redirected.
 
 node/111                                                              data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0
 data-products/dea/111/dea-surface-reflectance-nbar-landsat-deprecated data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0

--- a/docs/_redirects/cmi-pages.txt
+++ b/docs/_redirects/cmi-pages.txt
@@ -1,5 +1,7 @@
 # CMI pages redirects
 
+# Redirects from miscellaneous pages on the old CMI site to the new Knowledge Hub.
+
 node                     index
 404                      404-not-found
 search/user              search

--- a/docs/_redirects/cmi-themes.txt
+++ b/docs/_redirects/cmi-themes.txt
@@ -1,5 +1,7 @@
 # CMI Theme redirects
 
+# Redirects from the themes on the old CMI site to the new Knowledge Hub.
+
 theme/baseline-satellite-data  data/theme/baseline-satellite-data
 theme/land-and-vegetation      data/theme/land-and-vegetation
 theme/inland-water             data/theme/inland-water

--- a/docs/_redirects/cmi-themes.txt
+++ b/docs/_redirects/cmi-themes.txt
@@ -1,6 +1,6 @@
 # CMI Theme redirects
 
-# Redirects from the themes on the old CMI site to the new Knowledge Hub.
+# Redirects from the theme pages on the old CMI site to the new Knowledge Hub.
 
 theme/baseline-satellite-data  data/theme/baseline-satellite-data
 theme/land-and-vegetation      data/theme/land-and-vegetation

--- a/docs/_redirects/data-products.txt
+++ b/docs/_redirects/data-products.txt
@@ -1,6 +1,6 @@
 # Data Product redirects
 
-# Changed these URL slugs to be consistent with other similar products
+# Pages have been moved to a new URL
 
 data/product/dea-surface-reflectance-oa-landsat-9     data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data/product/dea-surface-reflectance-landsat-9        data/product/dea-surface-reflectance-landsat-9-oli-tirs

--- a/docs/_redirects/data-products.txt
+++ b/docs/_redirects/data-products.txt
@@ -1,5 +1,7 @@
 # Data Product redirects
 
+# Changed these URL slugs to be consistent with other similar products
+
 data/product/dea-surface-reflectance-oa-landsat-9     data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data/product/dea-surface-reflectance-landsat-9        data/product/dea-surface-reflectance-landsat-9-oli-tirs
 data/product/dea-surface-reflectance-nbart-landsat-9  data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs

--- a/docs/_redirects/data-products.txt
+++ b/docs/_redirects/data-products.txt
@@ -1,6 +1,6 @@
 # Data Product redirects
 
-# Pages have been moved to a new URL
+# Pages have been moved to a new URL.
 
 data/product/dea-surface-reflectance-oa-landsat-9     data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs
 data/product/dea-surface-reflectance-landsat-9        data/product/dea-surface-reflectance-landsat-9-oli-tirs

--- a/docs/_redirects/dea-docs-user-guides.txt
+++ b/docs/_redirects/dea-docs-user-guides.txt
@@ -1,4 +1,6 @@
-# CMI User Guide redirects
+# DEA Docs User Guide redirects
+
+# Redirects from old DEA Docs pages to the new Knowledge Hub.
 
 about/changelog         guides/tech_alerts_changelog
 about/faq               guides/about/faq

--- a/docs/_redirects/dea-docs-user-guides.txt
+++ b/docs/_redirects/dea-docs-user-guides.txt
@@ -1,6 +1,6 @@
 # DEA Docs User Guide redirects
 
-# Redirects from old DEA Docs pages to the new Knowledge Hub.
+# Redirects from locations on the old DEA Docs site to the new Knowledge Hub.
 
 about/changelog         guides/tech_alerts_changelog
 about/faq               guides/about/faq

--- a/docs/_redirects/external-data.txt
+++ b/docs/_redirects/external-data.txt
@@ -1,6 +1,6 @@
 # External Data redirects
 
-# Pages have moved to a new URL
+# Pages have moved to a new URL.
 
 data/external-data/ga-ausbathytopo  data/external-data/ga-ausbathytopo-250m
 data/external-data/ga-srtm          data/external-data/ga-srtm-1-second-dem

--- a/docs/_redirects/external-data.txt
+++ b/docs/_redirects/external-data.txt
@@ -1,6 +1,6 @@
 # External Data redirects
 
-# Changed these URL slugs to be more descriptive
+# Pages have moved to a new URL
 
 data/external-data/ga-ausbathytopo  data/external-data/ga-ausbathytopo-250m
 data/external-data/ga-srtm          data/external-data/ga-srtm-1-second-dem

--- a/docs/_redirects/external-data.txt
+++ b/docs/_redirects/external-data.txt
@@ -1,4 +1,6 @@
 # External Data redirects
 
+# Changed these URL slugs to be more descriptive
+
 data/external-data/ga-ausbathytopo  data/external-data/ga-ausbathytopo-250m
 data/external-data/ga-srtm          data/external-data/ga-srtm-1-second-dem

--- a/docs/_redirects/notebooks.txt
+++ b/docs/_redirects/notebooks.txt
@@ -1,6 +1,11 @@
 # Notebooks redirects
 
+# The new DEA Notebooks cover page sits on a different URL
+
 notebooks                      dea-notebooks
+
+# Category README pages
+
 notebooks/Beginners_guide      notebooks/Beginners_guide/README
 notebooks/DEA_products         notebooks/DEA_products/README
 notebooks/How_to_guides        notebooks/How_to_guides/README

--- a/docs/_redirects/notebooks.txt
+++ b/docs/_redirects/notebooks.txt
@@ -1,10 +1,10 @@
 # Notebooks redirects
 
-# The new DEA Notebooks cover page sits on a different URL
+# The new DEA Notebooks cover page is on a different URL
 
-notebooks                      dea-notebooks
+notebooks  dea-notebooks
 
-# Category README pages
+# Notebooks category URLs automatically redirect to the README page for the category
 
 notebooks/Beginners_guide      notebooks/Beginners_guide/README
 notebooks/DEA_products         notebooks/DEA_products/README

--- a/docs/_redirects/notebooks.txt
+++ b/docs/_redirects/notebooks.txt
@@ -1,10 +1,10 @@
 # Notebooks redirects
 
-# The new DEA Notebooks cover page is on a different URL
+# The new DEA Notebooks cover page is on a different URL.
 
 notebooks  dea-notebooks
 
-# Notebooks category URLs automatically redirect to the README page for the category
+# Notebooks category URLs automatically redirect to the README page for the category.
 
 notebooks/Beginners_guide      notebooks/Beginners_guide/README
 notebooks/DEA_products         notebooks/DEA_products/README

--- a/docs/_redirects/old-versions.txt
+++ b/docs/_redirects/old-versions.txt
@@ -1,5 +1,5 @@
 # Old product version redirects
 
-# These products have been superseded by newer versions
+# These products have been superseded by newer versions.
 
 data/product/dea-intertidal-elevation-landsat  data/old-version/dea-intertidal-elevation-landsat-1.0.0

--- a/docs/_redirects/old-versions.txt
+++ b/docs/_redirects/old-versions.txt
@@ -1,3 +1,5 @@
 # Old product version redirects
 
+# These products have been superseded by newer versions
+
 data/product/dea-intertidal-elevation-landsat  data/old-version/dea-intertidal-elevation-landsat-1.0.0

--- a/docs/_redirects/permalinks.txt
+++ b/docs/_redirects/permalinks.txt
@@ -1,4 +1,6 @@
 # Permalink redirects
 
+# A permalink is a link that is not likely to change. It should be based on a constant value, such as a product's eCat number or DOI
+
 # permalink/116268  data/product/dea-coastlines
 # permalink/111881  data/product/dea-hotspots

--- a/docs/_redirects/permalinks.txt
+++ b/docs/_redirects/permalinks.txt
@@ -1,6 +1,5 @@
 # Permalink redirects
 
-# A permalink is a link that is not likely to change. It should be based on a constant value, such as a product's eCat number or DOI.
+# A permalink is a link that is not likely to change. It should be based on a constant value, such as a product's eCat number (e.g. 'permalink/146090').
 
-# permalink/116268  data/product/dea-coastlines
-# permalink/111881  data/product/dea-hotspots
+# permalink/146090  data/product/dea-land-cover-landsat

--- a/docs/_redirects/permalinks.txt
+++ b/docs/_redirects/permalinks.txt
@@ -1,6 +1,6 @@
 # Permalink redirects
 
-# A permalink is a link that is not likely to change. It should be based on a constant value, such as a product's eCat number or DOI
+# A permalink is a link that is not likely to change. It should be based on a constant value, such as a product's eCat number or DOI.
 
 # permalink/116268  data/product/dea-coastlines
 # permalink/111881  data/product/dea-hotspots

--- a/docs/_redirects/tech-alerts-changelog.txt
+++ b/docs/_redirects/tech-alerts-changelog.txt
@@ -1,5 +1,5 @@
 # Tech Alerts and Changelog redirects
 
-# The Tech Alerts and Changelog was moved out of the User Guides section into its own section of the site
+# The Tech Alerts and Changelog was moved out of the User Guides section into its own section of the site.
 
 guides/tech_alerts_changelog  tech-alerts-changelog

--- a/docs/_redirects/tech-alerts-changelog.txt
+++ b/docs/_redirects/tech-alerts-changelog.txt
@@ -1,3 +1,5 @@
 # Tech Alerts and Changelog redirects
 
+# The Tech Alerts and Changelog was moved out of the User Guides section into its own section of the site
+
 guides/tech_alerts_changelog  tech-alerts-changelog

--- a/docs/_redirects/user-guides.txt
+++ b/docs/_redirects/user-guides.txt
@@ -1,3 +1,5 @@
 # User guide redirects
 
+# User guides whose URL has been changed
+
 guides/setup/gis/web_services  guides/setup/gis/README

--- a/docs/_redirects/user-guides.txt
+++ b/docs/_redirects/user-guides.txt
@@ -1,5 +1,5 @@
 # User guide redirects
 
-# User guides whose URL has been changed
+# User guides whose URL has been changed.
 
 guides/setup/gis/web_services  guides/setup/gis/README

--- a/docs/_redirects/validation.txt
+++ b/docs/_redirects/validation.txt
@@ -1,5 +1,7 @@
 # Validation redirects
 
+# The term 'Daily report' was changed to 'Site report' and therefore the location was added to the URL slug
+
 validation/daily-report             validation/site-report
 validation/daily-report/2023-11-27  validation/site-report/2023-11-27-NSW1
 validation/daily-report/2023-11-26  validation/site-report/2023-11-26-SA1

--- a/docs/_redirects/validation.txt
+++ b/docs/_redirects/validation.txt
@@ -1,6 +1,6 @@
 # Validation redirects
 
-# The term 'Daily report' was changed to 'Site report' and therefore the location was added to the URL slug
+# The term 'Daily report' was changed to 'Site report' and therefore the location was added to the URL slug.
 
 validation/daily-report             validation/site-report
 validation/daily-report/2023-11-27  validation/site-report/2023-11-27-NSW1


### PR DESCRIPTION
Explained the history and the reasons for the redirects in our Knowledge Hub website. This documentation will be useful for future users of the site to understand where all these redirects came from. Also corrected a mistake: the term 'CMI' was changed to 'DEA Docs' for one redirects file.