### PR TITLE
Adding and improving DEA Maps links on product pages

### DIFF
--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -46,6 +46,8 @@ tags:
 # Access
 
 maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-r7JEUiLzrVzwZIYcis6hVlMpDdT
+  #   name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_fc_3

--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -47,7 +47,7 @@ tags:
 
 maps: null
   # - link: https://maps.dea.ga.gov.au/#share=s-r7JEUiLzrVzwZIYcis6hVlMpDdT
-  #   name: null
+  #   name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_fc_3

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps: null
   # - link: https://maps.dea.ga.gov.au/#share=s-uTFeDOnmZpXV2Ub7kRC50Q0v4vj
-  #   name: null
+  #   name: See it on a map
 
 explorers: null
 

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -47,6 +47,8 @@ tags:
 # Access
 
 maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-uTFeDOnmZpXV2Ub7kRC50Q0v4vj
+  #   name: null
 
 explorers: null
 

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -47,7 +47,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-7YeWZKqWkF0Ctv5Av8RkHSWeNzQ
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/high_tide_comp_20p

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -49,7 +49,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-7YeWZKqWkF0Ctv5Av8RkHSWeNzQ
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/high_tide_comp_20p

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-1I12IwkLvoIRxnJkzeiGTAJ3qEL
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/item_v2

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -48,7 +48,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-1I12IwkLvoIRxnJkzeiGTAJ3qEL
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/item_v2

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-lkNZRIoEC2JixvX3a7RoCGR5czq
+  - link: https://maps.dea.ga.gov.au/#share=s-1WoTW0dJY5MKU58ovTgOcZEYc48
     name: See it on a map
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls9c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls9c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls9c_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer-aws.dea.ga.gov.au/products/ga_s2am_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -47,7 +47,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -47,7 +47,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2bm_ard_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -47,7 +47,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
+  - link: https://maps.dea.ga.gov.au/#share=s-gUnjTYg5uC5fDf0iTXDqo7hrlrw
     name: See it on a map
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-17NAuY4sv71TbyCDIu4JErGWU1S
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-eo2yPzDYVPLTJ1WHbFQM1Vu6M8v
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-ie760Ut5KtelVDjm4wauOTKJeg6
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-czCPOd989jf0H8ssWTc4BvnBkBg
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls9c_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -49,7 +49,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer-aws.dea.ga.gov.au/products/ga_s2am_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -48,7 +48,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -49,7 +49,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2bm_ard_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -48,7 +48,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
+  - link: https://maps.dea.ga.gov.au/#share=s-gUnjTYg5uC5fDf0iTXDqo7hrlrw
     name: See it on a map
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -48,7 +48,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer-aws.dea.ga.gov.au/products/ga_s2am_ard_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-mpoGYidqkggb7wfUexuv8LKbDX6
     name: null
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
+  - link: https://maps.dea.ga.gov.au/#share=s-gUnjTYg5uC5fDf0iTXDqo7hrlrw
     name: See it on a map
 
 explorers:

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -50,7 +50,7 @@ tags:
 
 maps:
   - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
-    name: null
+    name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2bm_ard_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -49,7 +49,7 @@ tags:
 # Access
 
 maps:
-  - link: https://maps.dea.ga.gov.au/
+  - link: https://maps.dea.ga.gov.au/#share=s-qB1fcm3zd0IrSJC70CNXLZMMO7Q
     name: null
 
 explorers:

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -51,7 +51,7 @@ tags:
 
 maps: null
   # - link: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
-  #   name: null
+  #   name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_tc_pc_cyear_3

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -49,7 +49,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_tc_pc_cyear_3

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -49,9 +49,9 @@ tags:
 
 # Access
 
-maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
-    name: null
+maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
+  #   name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_tc_pc_cyear_3

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -46,9 +46,9 @@ tags:
 
 # Access
 
-maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
-    name: null
+maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
+  #   name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_wo_3

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -48,7 +48,7 @@ tags:
 
 maps: null
   # - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
-  #   name: null
+  #   name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_wo_3

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -46,7 +46,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_wo_3

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -49,7 +49,7 @@ tags:
 
 maps: null
   # - link: https://maps.dea.ga.gov.au/#share=s-oO5CFFpKC3Rn1aPCZFYeg97SheY
-  #   name: null
+  #   name: See it on a map
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2_wo_provisional_3

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -47,9 +47,9 @@ tags:
 
 # Access
 
-maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-oO5CFFpKC3Rn1aPCZFYeg97SheY
-    name: null
+maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-oO5CFFpKC3Rn1aPCZFYeg97SheY
+  #   name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2_wo_provisional_3

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -47,7 +47,9 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-oO5CFFpKC3Rn1aPCZFYeg97SheY
+    name: null
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_s2_wo_provisional_3

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -50,7 +50,15 @@ tags:
 
 # Access
 
-maps: null
+maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-yIyPPjQlWxVBLg10WJBQd8KrMgt
+    name: Apr-Oct summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-vT2uXq2ZYxfuKzHZTYM7Xc9kXY0
+    name: Nov-Mar summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-5fLlPp0Fk11iLTxUpCQPxTkVAH3
+    name: Annual calendar year summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-x0R0IFIqxSFDJ54LK6sFDEfjh6i
+    name: All-time summary on DEA Maps
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products#inland-water-group

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -50,15 +50,15 @@ tags:
 
 # Access
 
-maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-yIyPPjQlWxVBLg10WJBQd8KrMgt
-    name: Apr-Oct summaries on DEA Maps
-  - link: https://maps.dea.ga.gov.au/#share=s-vT2uXq2ZYxfuKzHZTYM7Xc9kXY0
-    name: Nov-Mar summaries on DEA Maps
-  - link: https://maps.dea.ga.gov.au/#share=s-5fLlPp0Fk11iLTxUpCQPxTkVAH3
-    name: Annual calendar year summaries on DEA Maps
-  - link: https://maps.dea.ga.gov.au/#share=s-x0R0IFIqxSFDJ54LK6sFDEfjh6i
-    name: All-time summary on DEA Maps
+maps: null
+  # - link: https://maps.dea.ga.gov.au/#share=s-yIyPPjQlWxVBLg10WJBQd8KrMgt
+  #   name: Apr-Oct summaries on DEA Maps
+  # - link: https://maps.dea.ga.gov.au/#share=s-vT2uXq2ZYxfuKzHZTYM7Xc9kXY0
+  #   name: Nov-Mar summaries on DEA Maps
+  # - link: https://maps.dea.ga.gov.au/#share=s-5fLlPp0Fk11iLTxUpCQPxTkVAH3
+  #   name: Annual calendar year summaries on DEA Maps
+  # - link: https://maps.dea.ga.gov.au/#share=s-x0R0IFIqxSFDJ54LK6sFDEfjh6i
+  #   name: All-time summary on DEA Maps
 
 explorers:
   - link: https://explorer.dea.ga.gov.au/products#inland-water-group


### PR DESCRIPTION
This PR originated from https://github.com/GeoscienceAustralia/dea-knowledge-hub/pull/274 but is more focussed and single-purpose.

**Adding DEA Maps links on product pages**

* These links appear on the product pages as "See it on a map"

**Product contact approvals:**

The RED (Cedric) related changes are commented out so that they don't overlap with the RED project.

| Product(s) | Contact | Status |
|--------|--------|--------|
| Wetlands Insight Tool, WO, WO Stats, WO Sentinel-2 | Bex | Approved |
| DEA Mangroves, High and Low Tide Imagery, Intertidal Extents | Stephen | Approved |
| FC, FC Percentiles, WO, WO Stats, Tasseled Cap | Cedric | Pending | 
| Surface Reflectance products | Imam | Approved |
