### PR TITLE
Removed the sphinxext.opengraph extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ extensions = [
     "sphinxcontrib.datatemplates",
     "sphinx_external_toc",
     "sphinx_sitemap",
-    "sphinxext.opengraph",
     "notfound.extension",
     "sphinx_copybutton",
     # "sphinx_tags",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,6 @@ sphinxext-rediraffe<=0.2.7
 sphinxcontrib.datatemplates<=0.10.2
 sphinx-external-toc<=1.0.1
 sphinx-sitemap<=2.5.1
-sphinxext-opengraph<=0.9.1
 sphinx-notfound-page<=1.0.0
 sphinx-copybutton<=0.5.2
 


### PR DESCRIPTION
Removing this for the following reasons.

* More consistency of page titles displayed on Google
* Simplicity
* The extension didn't add much value

The following HTML head fields will no longer exist on all pages.

```html
<meta property="og:title" content="Getting started" />
<meta property="og:type" content="website" />
<meta property="og:url" content="https://knowledge.dea.ga.gov.au/guides/setup/README/" />
<meta property="og:site_name" content="DEA Knowledge Hub" />
<meta property="og:description" content="To access DEA data and resources, use one of our DEA Services. Or, to use DEA Products, you can get started quickly by using pre-built instances and examples and installing some software tools. In ..." />
<meta property="og:image" content="https://knowledge.dea.ga.gov.au/_files/logos/dea-logo-inline.png" />
<meta property="og:image:alt" content="DEA Knowledge Hub" />
<meta name="description" content="To access DEA data and resources, use one of our DEA Services. Or, to use DEA Products, you can get started quickly by using pre-built instances and examples and installing some software tools. In ..." />
```