### PR TITLE
Footer updates

### DIFF
--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -4,7 +4,7 @@
             <p class="footer-heading">Related websites</p>
             <ul>
                 <li><a href="https://www.ga.gov.au/">Geoscience Australia</a></li>
-                <li><a href="https://www.dea.ga.gov.au/">Digital Earth Australia</a></li>
+                <li><a href="https://www.ga.gov.au/scientific-topics/dea">Digital Earth Australia</a></li>
                 <li><a href="https://www.digitalearthafrica.org/">Digital Earth Africa</a></li>
                 <li><a href="https://www.opendatacube.org/">Open Data Cube</a></li>
             </ul>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -51,4 +51,9 @@
         </div>
     </div>
     {% endif %}
+    <div class="row">
+        <div class="col-12">
+            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?logo=github&label=GitHub:+dea-knowledge-hub"></a>
+        </div>
+    </div>
 </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -26,6 +26,11 @@
     </div>
     <div class="row">
         <div class="col-12 policy-links">
+            <p><strong>Open source:</strong> The codebase for this website is on GitHub: <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GeoscienceAustralia/dea-knowledge-hub</a></p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-12 policy-links">
             <div>
                 <hr>
                 <ul>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="row">
-        <div class="col-12 col-sm-6 col-md-3">
-            <p class="footer-heading">Related websites</p>
+        <div class="col-12 col-sm-6 col-md-3 footer--related-websites">
+            <p class="footer--heading">Related websites</p>
             <ul>
                 <li><a href="https://www.ga.gov.au/">Geoscience Australia</a></li>
                 <li><a href="https://www.ga.gov.au/scientific-topics/dea">Digital Earth Australia</a></li>
@@ -9,23 +9,23 @@
                 <li><a href="https://www.opendatacube.org/">Open Data Cube</a></li>
             </ul>
         </div>
-        <div class="col-12 col-sm-6 col-md-3">
-            <p class="footer-heading">Get support</p>
+        <div class="col-12 col-sm-6 col-md-3 footer--support">
+            <p class="footer--heading">Get support</p>
             <ul>
                 <li><a href="https://www.ga.gov.au/scientific-topics/dea/contact-us">Contact us</a></li>
                 <li><a href="https://gis.stackexchange.com/questions/tagged/open-data-cube">ODC Stack Exchange</a></li>
                 <li><a href="https://discord.com/invite/4hhBQVas5U">ODC Discord chat</a></li>
             </ul>
         </div>
-        <div class="col-12 col-md-6">
-            <div id="acknowledgement-of-country">
-                <p class="footer-heading">Acknowledgement of country</p>
+        <div class="col-12 col-md-6 footer--acknowledgement-of-country">
+            <div>
+                <p class="footer--heading">Acknowledgement of country</p>
                 <p>Geoscience Australia acknowledges the traditional owners and custodians of Country throughout Australia and acknowledges their continuing connection to land, waters and community. We pay our respects to the people, the cultures and the elders past and present. Digital Earth Australia is a program of Geoscience Australia.</p>
             </div>
         </div>
     </div>
     <div class="row">
-        <div class="col-12 policy-links">
+        <div class="col-12 footer--policy-links">
             <div>
                 <hr>
                 <ul>
@@ -39,20 +39,22 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GitHub%3A%20GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
+        <div class="col-12 footer--badges">
+            <div>
+                <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GitHub%3A%20GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
+            </div>
         </div>
     </div>
     {% if show_copyright and copyright %}
     <div class="row">
-        <div class="col-12">
-            <div class="footer-copyright">
+        <div class="col-12 footer--copyright">
+            <p>
                 {% if hasdoc('copyright') %}
                 {% trans path=pathto('copyright'), copyright=copyright|e %}© <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
                 {% else %}
                 {% trans copyright=copyright|e %}© Copyright {{ copyright }}.{% endtrans %}
                 {% endif %}
-            </div>
+            </p>
         </div>
     </div>
     {% endif %}

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -38,6 +38,11 @@
             </div>
         </div>
     </div>
+    <div class="row">
+        <div class="col-12">
+            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?logo=github&label=GitHub:+dea-knowledge-hub"></a>
+        </div>
+    </div>
     {% if show_copyright and copyright %}
     <div class="row">
         <div class="col-12">
@@ -51,9 +56,4 @@
         </div>
     </div>
     {% endif %}
-    <div class="row">
-        <div class="col-12">
-            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?logo=github&label=GitHub:+dea-knowledge-hub"></a>
-        </div>
-    </div>
 </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -3,9 +3,9 @@
         <div class="col-12 col-sm-6 col-md-3">
             <p class="footer-heading">Related websites</p>
             <ul>
+                <li><a href="https://www.ga.gov.au/">Geoscience Australia</a></li>
                 <li><a href="https://www.dea.ga.gov.au/">Digital Earth Australia</a></li>
                 <li><a href="https://www.digitalearthafrica.org/">Digital Earth Africa</a></li>
-                <li><a href="https://www.ga.gov.au/">Geoscience Australia</a></li>
                 <li><a href="https://www.opendatacube.org/">Open Data Cube</a></li>
             </ul>
         </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -12,7 +12,6 @@
         <div class="col-12 col-sm-6 col-md-3">
             <p class="footer-heading">Get support</p>
             <ul>
-                <li><a href="/guides/about/glossary/">Glossary</a></li>
                 <li><a href="https://www.ga.gov.au/scientific-topics/dea/contact-us">Contact us</a></li>
                 <li><a href="https://gis.stackexchange.com/questions/tagged/open-data-cube">ODC Stack Exchange</a></li>
                 <li><a href="https://discord.com/invite/4hhBQVas5U">ODC Discord chat</a></li>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -22,11 +22,10 @@
                 <p class="footer-heading">Acknowledgement of country</p>
                 <p>Geoscience Australia acknowledges the traditional owners and custodians of Country throughout Australia and acknowledges their continuing connection to land, waters and community. We pay our respects to the people, the cultures and the elders past and present. Digital Earth Australia is a program of Geoscience Australia.</p>
             </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12 policy-links">
-            <p><strong>Open source:</strong> The codebase for this website is on GitHub: <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GeoscienceAustralia/dea-knowledge-hub</a></p>
+            <div>
+                <p class="footer-heading">Open source</p>
+                <p>The GitHub code repository of this website is <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GeoscienceAustralia/dea-knowledge-hub</a></p>
+            </div>
         </div>
     </div>
     <div class="row">

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -22,10 +22,6 @@
                 <p class="footer-heading">Acknowledgement of country</p>
                 <p>Geoscience Australia acknowledges the traditional owners and custodians of Country throughout Australia and acknowledges their continuing connection to land, waters and community. We pay our respects to the people, the cultures and the elders past and present. Digital Earth Australia is a program of Geoscience Australia.</p>
             </div>
-            <div>
-                <p class="footer-heading">Open source</p>
-                <p>The GitHub code repository of this website is <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GeoscienceAustralia/dea-knowledge-hub</a></p>
-            </div>
         </div>
     </div>
     <div class="row">

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -41,7 +41,7 @@
     <div class="row">
         <div class="col-12 footer--badges">
             <div>
-                <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GitHub%3A%20GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
+                <a title="GitHub repository" href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
             </div>
         </div>
     </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -40,7 +40,7 @@
     </div>
     <div class="row">
         <div class="col-12">
-            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?logo=github&label=GitHub:+dea-knowledge-hub"></a>
+            <a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GitHub%3A%20GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
         </div>
     </div>
     {% if show_copyright and copyright %}

--- a/docs/_static/styles/components/_footer.scss
+++ b/docs/_static/styles/components/_footer.scss
@@ -6,7 +6,7 @@ footer.bd-footer {
         $text-color
     );
 
-    p, a, .footer-copyright {
+    p, li, a {
         color: white;
     }
 
@@ -20,12 +20,6 @@ footer.bd-footer {
         }
     }
 
-    .footer-heading {
-        font-size: 1.375rem;
-        font-weight: bold;
-        margin-bottom: 1.05rem;
-    }
-
     ul {
         list-style-type: none;
         margin: 0;
@@ -34,15 +28,6 @@ footer.bd-footer {
 
     li {
         margin-bottom: 1rem;
-    }
-
-    .policy-links li {
-        display: inline;
-        margin-right: 2rem;
-
-        @media only screen and (max-width: $breakpoint-xl) {
-            line-height: 2rem;
-        }
     }
 
     .footer-items__start,
@@ -55,13 +40,51 @@ footer.bd-footer {
         text-align: left;
     }
 
-    .footer-copyright {
-        margin-top: 1rem;
-    }
+    .footer {
+        &--heading {
+            font-size: 1.375rem;
+            font-weight: bold;
+            margin-bottom: 1.05rem;
+        }
 
-    @media only screen and (max-width: $breakpoint-md) {
-        #acknowledgement-of-country {
-            margin-top: 1rem;
+        &--related-websites {}
+
+        &--support{}
+
+        &--acknowledgement-of-country {
+            & > div {
+                @media only screen and (max-width: $breakpoint-md) {
+                    margin-top: 1rem;
+                }
+            }
+
+        }
+
+        &--policy-links {
+            li {
+                display: inline;
+                margin-right: 2rem;
+
+                @media only screen and (max-width: $breakpoint-xl) {
+                    line-height: 2rem;
+                }
+            }
+        }
+
+        &--badges {
+            & > div {
+                margin-top: 1rem;
+            }
+        }
+
+        &--copyright {
+            & > div {
+                margin-top: 1rem;
+            }
+
+            p {
+                margin-bottom: 0;
+            }
         }
     }
 }

--- a/docs/_static/styles/components/_footer.scss
+++ b/docs/_static/styles/components/_footer.scss
@@ -78,11 +78,8 @@ footer.bd-footer {
         }
 
         &--copyright {
-            & > div {
+            & > p {
                 margin-top: 1rem;
-            }
-
-            p {
                 margin-bottom: 0;
             }
         }


### PR DESCRIPTION
Updates to footer links:

* New DEA website URL
* Reordering links so GA link is at top.
* Removed Glossary link because these footer links should be all external links.
* Added a 'badge' that links to the GitHub repo. This shows that the website is open source.
* Refactored the stylesheet for the footer.