### PR TITLE
Moved GA tracking code to the top of the head section

### DIFF
--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -11,14 +11,6 @@
 {%- endblock %}
 
 {% block extrahead %}
-{%- if meta_keywords %}
-<meta name="keywords" content="{{ meta_keywords }}">
-{%- endif %}
-
-<script type="text/javascript" src="/_static/scripts/content-root.js"></script>
-<script type="text/javascript" src="/_static/scripts/custom-behaviour.js"></script>
-<script type="text/javascript" src="/_static/scripts/lightbox.js"></script>
-
 {%- if google_analytics_ga4_tag %}
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics_ga4_tag }}"></script>
@@ -30,5 +22,13 @@
     gtag('config', '{{ google_analytics_ga4_tag }}');
 </script>
 {%- endif %}
+
+{%- if meta_keywords %}
+<meta name="keywords" content="{{ meta_keywords }}">
+{%- endif %}
+
+<script type="text/javascript" src="/_static/scripts/content-root.js"></script>
+<script type="text/javascript" src="/_static/scripts/custom-behaviour.js"></script>
+<script type="text/javascript" src="/_static/scripts/lightbox.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
As per the new Google Analytics instructions. "Copy and paste it in the code of every page of your website, immediately after the <head> element."