### PR TITLE
Added super to one layout block

### DIFF
--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -30,5 +30,7 @@
 <script type="text/javascript" src="/_static/scripts/content-root.js"></script>
 <script type="text/javascript" src="/_static/scripts/custom-behaviour.js"></script>
 <script type="text/javascript" src="/_static/scripts/lightbox.js"></script>
+
+{{ super() }}
 {% endblock %}
 


### PR DESCRIPTION
Extended the `extrahead` layout block using `super()`. This will extend upon the Pydata theme's 'extrahead' content: https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html#L33

Currently, that Pydata content is:

```html
{%- block extrahead %}
  <meta name="viewport" content="width=device-width, initial-scale=1"/>
  <meta name="docsearch:language" content="{{ language }}"/>
  <meta name="docsearch:version" content="{{ version }}" />
  {%- if last_updated %}
    <meta name="docbuild:last-update" content="{{ last_updated | e }}"/>
  {%- endif %}
{%- endblock extrahead %}
```

The other block `htmltitle` does not use 'super' because it is instead overwritten by custom title code.