### PR TITLE
Updated tech alert: Sentinel-2 data missing from AWS over inland Australia between November 2023 and February 2024 to be restored

### DIFF
--- a/docs/tech-alerts/_content.md
+++ b/docs/tech-alerts/_content.md
@@ -8,9 +8,11 @@
 Learn more about the [DEA Summary Product Grid](/guides/reference/collection_3_summary_grid/).
 ::::
 
-## 16 Dec 2024: Missing Sentinel-2 data between November 2023 and February 2024 in AWS database only
+## 16 Dec 2024: Sentinel-2 data missing from AWS over inland Australia between November 2023 and February 2024 to be restored
 
-We are aware of missing Sentinel-2 data in DEA's AWS database over inland Australia between November 2023 and February 2024. This was caused by a syncing issue between the NCI and AWS. You can still access this data from our NCI database. We are working on restoring this data in our AWS database.
+We are aware of missing Sentinel-2 data in [DEA's Amazon Web Services (AWS) database](https://explorer.dea.ga.gov.au/products) over inland Australia between November 2023 and February 2024. This was caused by a syncing issue between the National Computational Infrastructure (NCI) and AWS. You can still access this data from our [NCI database](https://explorer.nci.dea.ga.gov.au/products). We are working on restoring this data in our AWS database.
+
+[View the Tech Alert](https://communication.ga.gov.au/link/id/zzzz675fa96fc6dd0277Pzzzz6567c8b713b5b826/page.html)
 
 ## 12 Dec 2024: Critical support only over Christmas&ndash;New Year
 


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Updated the tech alert based on Tech Alert email content.
