### PR TITLE
Add bands link to Key specifications and removed links from header

### DIFF
--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -359,7 +359,7 @@
         - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
       {%- elif bands_table_list and bands_count == 2 %}
       * - **Bands**
-        - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}) <./?tab=specifications>`_
+        - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }} and {{ bands_table_list[1].name }}) <./?tab=specifications>`_
       {%- elif bands_table_list and bands_count == 1 %}
       * - **Bands**
         - `{{ bands_count }} band of data ({{ bands_table_list[0].name }}) <./?tab=specifications>`_

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -356,10 +356,10 @@
       {%- endif %}
       {% if bands_table_list and bands_count > 3 %}
       * - **Bands**
-        - `This product has {{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
+        - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
       {%- elif bands_table_list %}
       * - **Bands**
-        - `This product has {{ bands_count }} bands of data <./?tab=specifications>`_
+        - `{{ bands_count }} bands of data <./?tab=specifications>`_
       {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -196,26 +196,16 @@
 
       .. rubric:: {{ display_title }}
 
-      {% if product_ids_list and page.data.enable_specifications %}
-      `{{ product_ids_list_text }} <./?tab=specifications>`_
-      {%- elif product_ids_list %}
+      {% if product_ids_list %}
       {{ product_ids_list_text }}
-      {%- elif spatial_data_type == spatial_data_type_terms.VECTOR and page.data.enable_specifications %}
-      `Vector product <./?tab=specifications>`_
       {%- elif spatial_data_type == spatial_data_type_terms.VECTOR %}
       Vector product
-      {%- elif page.data.enable_specifications %}
-      `Data product <./?tab=specifications>`_
       {%- else %}
       Data product
       {%- endif %}
 
-      {% if page.data.is_latest_version and page.data.enable_history %}
-      :Version: `{{ page.data.version_number }} <./?tab=history>`_
-      {%- elif page.data.is_latest_version %}
+      {% if page.data.is_latest_version %}
       :Version: {{ page.data.version_number }}
-      {%- elif page.data.enable_history %}
-      :Version: `{{ page.data.version_number }} <./?tab=history>`_ (`See latest version <{{ page.data.latest_version_link }}>`_)
       {%- else %}
       :Version: {{ page.data.version_number }} (`See latest version <{{ page.data.latest_version_link }}>`_)
       {%- endif %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -206,7 +206,9 @@
       Data product
       {%- endif %}
 
-      {% if page.data.is_latest_version %}
+      {% if page.data.is_latest_version and page.data.enable_history %}
+      :Version: `{{ page.data.version_number }} <./?tab=history>`_
+      {%- elif page.data.is_latest_version %}
       :Version: {{ page.data.version_number }}
       {%- else %}
       :Version: {{ page.data.version_number }} (`See latest version <{{ page.data.latest_version_link }}>`_)

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -90,6 +90,8 @@
 
 {% set bands_table_list = page.tables.bands_table | selectattr("name", "!=", None) | list %}
 
+{% set bands_count = bands_table_list | length %}
+
 {% set page_title = page.data.short_name if page.data.is_latest_version else "v{}. {}".format(page.data.version_number, page.data.short_name) %}
 
 {% set display_title = page.data.short_name if page.data.is_latest_version else "{} v{}".format(page.data.short_name, page.data.version_number) %}
@@ -354,7 +356,7 @@
       {%- endif %}
       {% if bands_table_list %}
       * - **Bands**
-        - `View {{ bands_table_list | length }} bands <./?tab=specifications>`_
+        - `View {{ bands_count }} bands <./?tab=specifications>`_
       {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -352,6 +352,10 @@
       * - **Technical name**
         - {{ page.data.full_technical_name }}
       {%- endif %}
+      {% if bands_table_list %}
+      * - **Bands**
+        - `View {{ bands_table_list | length }} bands <./?tab=specifications>`_
+      {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**
         - `{{ page.data.doi }} <https://doi.org/{{ page.data.doi }}>`_

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -196,7 +196,9 @@
 
       .. rubric:: {{ display_title }}
 
-      {% if product_ids_list %}
+      {% if product_ids_list and page.data.enable_specifications %}
+      `{{ product_ids_list_text }} <./?tab=specifications>`_
+      {%- elif product_ids_list %}
       {{ product_ids_list_text }}
       {%- elif spatial_data_type == spatial_data_type_terms.VECTOR %}
       Vector product

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -357,10 +357,10 @@
       {% if bands_table_list and bands_count >= 3 %}
       * - **Bands**
         - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
-      {%- elif bands_table_list == 2 %}
+      {%- elif bands_table_list and bands_count == 2 %}
       * - **Bands**
         - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}) <./?tab=specifications>`_
-      {%- elif bands_table_list == 1 %}
+      {%- elif bands_table_list and bands_count == 1 %}
       * - **Bands**
         - `{{ bands_count }} band of data ({{ bands_table_list[0].name }}) <./?tab=specifications>`_
       {%- endif %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -354,12 +354,15 @@
       * - **Technical name**
         - {{ page.data.full_technical_name }}
       {%- endif %}
-      {% if bands_table_list and bands_count > 3 %}
+      {% if bands_table_list and bands_count >= 3 %}
       * - **Bands**
         - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
-      {%- elif bands_table_list %}
+      {%- elif bands_table_list == 2 %}
       * - **Bands**
-        - `{{ bands_count }} bands of data <./?tab=specifications>`_
+        - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}) <./?tab=specifications>`_
+      {%- elif bands_table_list == 1 %}
+      * - **Bands**
+        - `{{ bands_count }} band of data ({{ bands_table_list[0].name }}) <./?tab=specifications>`_
       {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -354,7 +354,10 @@
       * - **Technical name**
         - {{ page.data.full_technical_name }}
       {%- endif %}
-      {% if bands_table_list %}
+      {% if bands_table_list and bands_count > 3 %}
+      * - **Bands**
+        - `View {{ bands_count }} bands ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
+      {%- elif bands_table_list %}
       * - **Bands**
         - `View {{ bands_count }} bands <./?tab=specifications>`_
       {%- endif %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -356,10 +356,10 @@
       {%- endif %}
       {% if bands_table_list and bands_count > 3 %}
       * - **Bands**
-        - `View {{ bands_count }} bands ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
+        - `This product has {{ bands_count }} bands of data ({{ bands_table_list[0].name }}, {{ bands_table_list[1].name }}, and more) <./?tab=specifications>`_
       {%- elif bands_table_list %}
       * - **Bands**
-        - `View {{ bands_count }} bands <./?tab=specifications>`_
+        - `This product has {{ bands_count }} bands of data <./?tab=specifications>`_
       {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -362,7 +362,7 @@
         - `{{ bands_count }} bands of data ({{ bands_table_list[0].name }} and {{ bands_table_list[1].name }}) <./?tab=specifications>`_
       {%- elif bands_table_list and bands_count == 1 %}
       * - **Bands**
-        - `{{ bands_count }} band of data ({{ bands_table_list[0].name }}) <./?tab=specifications>`_
+        - `Single band of data ({{ bands_table_list[0].name }}) <./?tab=specifications>`_
       {%- endif %}
       {%- if page.data.doi %}
       * - **DOI**


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

* On the Overview tab of product pages, add a link to the bands table to the Key specifications section. This aims to highlight this new and important feature of the product pages so that more visitors will notice this feature.
* ~~Removed the 'mouse hover' links from the product header since they are not really needed since the Key specifications section links to the Specifications tab. Furthermore, a) the link makes it harder to copy the product ID using the mouse, which is something that is commonly done when loading data from the Datacube, b) the links 'flash' annoyingly when the page loads.~~
    * ~~However, now the product ID is just in plain text with no label or link. Do you think this may confuse the user who doesn't know what that ID actually means? If so, I can think of a design solution for this. E.g. I can add the Product ID to the Key specifications section? Or, I can add the label 'Product ID:' in front of the Product ID in the header?~~

**Preview:** https://pr-362-preview.khpreview.dea.ga.gov.au/data/product/dea-intertidal/
