### PR TITLE
Adding the Validation Reports to the top menu bar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,7 @@ html_theme_options = {
     "navigation_with_keys": False,
     "search_bar_text": "Search ...",
     "show_prev_next": False,
-    "header_links_before_dropdown": 4, # The number of header menu items to display before the rest are nested inside the 'More' dropdown.
+    "header_links_before_dropdown": 5, # The number of header menu items to display before the rest are nested inside the 'More' dropdown.
     "logo": {
         "link": "/"
     },

--- a/docs/table_of_contents.yaml
+++ b/docs/table_of_contents.yaml
@@ -223,20 +223,6 @@ entries:
         entries:
           - file: notebooks/Tools/index # Contains its own table of contents.
 
-  # DEA Tech Alerts
-
-  - file: tech-alerts/index
-    title: Tech Alerts
-    subtrees:
-      - caption: Previous years
-        entries:
-          - file: tech-alerts/previous-years/index
-            title: View previous years
-            options:
-              reversed: True
-            entries:
-              - glob: tech-alerts/*/index
-
   # Validation
 
   - file: validation/index
@@ -281,6 +267,20 @@ entries:
       #         reversed: True
       #       entries:
       #         - glob: validation/yearly-report/*/index
+
+  # DEA Tech Alerts
+
+  - file: tech-alerts/index
+    title: Tech Alerts
+    subtrees:
+      - caption: Previous years
+        entries:
+          - file: tech-alerts/previous-years/index
+            title: View previous years
+            options:
+              reversed: True
+            entries:
+              - glob: tech-alerts/*/index
 
   # Operational reports
 


### PR DESCRIPTION
Adding the Validation Reports menu item to the top menu bar instead of being nested in the More sub-menu

<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

