### PR TITLE
Added a 'New' indicator to the Specifications tab

### DIFF
--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -474,7 +474,7 @@
 
 {% set specifications_tab_component %}
 {% if page.data.enable_specifications %}
-.. tab-item:: Specifications
+.. tab-item:: Specifications (New)
    :name: specifications
 
    .. raw:: html

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -474,7 +474,7 @@
 
 {% set specifications_tab_component %}
 {% if page.data.enable_specifications %}
-.. tab-item:: Specifications (New)
+.. tab-item:: Specifications :raw-html:`&#x2728;`
    :name: specifications
 
    .. raw:: html


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Added the Sparkles emoji to the Specifications tab in the Product V2 template. I will remove this in 1-2 months.

Preview: https://pr-367-preview.khpreview.dea.ga.gov.au/data/product/dea-intertidal/?tab=specifications