### PR TITLE
Update tech alert card banners

### DIFF
--- a/docs/tech-alerts/_content.md
+++ b/docs/tech-alerts/_content.md
@@ -46,7 +46,7 @@ New user account creation for the [DEA Sandbox](https://app.sandbox.dea.ga.gov.a
 
 [View the Tech Alert](https://communication.ga.gov.au/link/id/zzzz675a766b4e320946Pzzzz6567c8b713b5b826/page.html)
 
-## 5 Dec 2024: NCI database will be upgraded soon. Service disruption is possible but not expected.
+## 5 Dec 2024: NCI database will be upgraded soon. Service disruption is possible but not expected. (Resolved)
 
 The NCI database will soon be upgraded. According to our testing, downtime or major disruption to service is not expected. However, be aware that a service disruption is still possible during this time.
 

--- a/docs/tech-alerts/_data.yaml
+++ b/docs/tech-alerts/_data.yaml
@@ -6,16 +6,16 @@ meta_description: null
 quick_links_custom: null
 
 system_status_notifications:
-  - description: NCI database will be upgraded soon. Service disruption is possible but not expected.
+  - description: DEA Maps and OWS services are not updating. See below.
     severity: 2
     status_custom: null
 
   - description: Expanded extents data processing is currently paused, with data available to May 2024. See below. # NOTE Remember to remove the banner on the page: https://pr-302-preview.khpreview.dea.ga.gov.au/guides/reference/ard-expanded-processing-extent/
-    severity: 2
+    severity: 3
     status_custom: null
 
   - description: Misclassification issue with Sentinel-2 ‘s2cloudless’ cloud masking from 2022. See below.
-    severity: 2
+    severity: 3
     status_custom: null
 
   - description: Terra-derived DEA Hotspots are unavailable. See below.
@@ -23,9 +23,5 @@ system_status_notifications:
     status_custom: null
 
   - description: NCI Explorer may experience instability. See below.
-    severity: 3
-    status_custom: null
-
-  - description: GeoMAD processing bug. See below.
     severity: 2
     status_custom: null


### PR DESCRIPTION
Update the Tech Alert card banner with the latest status of issues:
- remove NCI database upgrade warning. 
- downgrade expand extents to a note
- downgrade s2 cloudless to a note
- remove geoMAD bug
- upgrade NCI Explorer to warning
- Add DEA Maps out of date.

