### PR TITLE
Sentinel-2A products have 'No further updates'

### DIFF
--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -20,8 +20,8 @@ temporal_coverage_end: Present
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY
-data_update_activity: ONGOING
-is_currency_reported: true
+data_update_activity: NO_UPDATES
+is_currency_reported: false
 
 resolution: 10-60 m
 coordinate_reference_system: null

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -16,7 +16,7 @@ spatial_data_type: RASTER
 
 spatial_coverage: null
 temporal_coverage_start: 12 Jul 2015
-temporal_coverage_end: Present
+temporal_coverage_end: 21 Jan 2025
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -20,8 +20,8 @@ temporal_coverage_end: Present
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY
-data_update_activity: ONGOING
-is_currency_reported: true
+data_update_activity: NO_UPDATES
+is_currency_reported: false
 
 resolution: 10-60 m
 coordinate_reference_system: null

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -16,7 +16,7 @@ spatial_data_type: RASTER
 
 spatial_coverage: null
 temporal_coverage_start: 12 Jul 2015
-temporal_coverage_end: Present
+temporal_coverage_end: 21 Jan 2025
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -20,8 +20,8 @@ temporal_coverage_end: Present
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY
-data_update_activity: ONGOING
-is_currency_reported: true
+data_update_activity: NO_UPDATES
+is_currency_reported: false
 
 resolution: 10-60 m
 coordinate_reference_system: null

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -16,7 +16,7 @@ spatial_data_type: RASTER
 
 spatial_coverage: null
 temporal_coverage_start: 12 Jul 2015
-temporal_coverage_end: Present
+temporal_coverage_end: 21 Jan 2025
 temporal_coverage_custom: null
 
 data_update_frequency: DAILY


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

* Sentinel-2A products have 'No further updates'.
* Sentinel-2A products don't link to the Currency Report anymore.
* Set temporal_coverage_end to 21 Jan 2025.

Preview: https://pr-385-preview.khpreview.dea.ga.gov.au/data/category/sentinel-2a-analysis-ready-data/