### PR TITLE
Fix for access date not appearing on some citations

### DIFF
--- a/docs/_templates/external-data-v1.rst
+++ b/docs/_templates/external-data-v1.rst
@@ -226,14 +226,14 @@
           {% if Data.citations.paper_citation %}
           * - **Paper citation**
             - .. code-block:: text
-                 :class: citation-table-citation
+                 :class: citation-table-citation citation-access-date
 
                  {{ Data.citations.paper_citation }}
           {%- endif %}
           {% for citation in valid_custom_citations %}
           * - **{{ citation.name }}**
             - .. code-block:: text
-                 :class: citation-table-citation
+                 :class: citation-table-citation citation-access-date
 
                  {{ citation.citation }}
           {% endfor %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -420,14 +420,14 @@
       {% if page.data.citation_paper %}
       * - **Paper citation**
         - .. code-block:: text
-             :class: citation-table-citation
+             :class: citation-table-citation citation-access-date
 
              {{ page.data.citation_paper }}
       {%- endif %}
       {% for citation in citations_custom_list %}
       * - **{{ citation.name }}**
         - .. code-block:: text
-             :class: citation-table-citation
+             :class: citation-table-citation citation-access-date
 
              {{ citation.citation }}
       {% endfor %}


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Issue: The access date was not being automatically added to Paper Citations and Custom Citations. It was only appearing on the Data Citation.

Solution: Add the necessary CSS class to those other two HTML elements in the product and external data templates.

Preview:

* https://pr-388-preview.khpreview.dea.ga.gov.au/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/#citations
* https://pr-388-preview.khpreview.dea.ga.gov.au/data/product/dea-coastlines/#citations