### PR TITLE
Remove _components pages from public site

### DIFF
--- a/docs/_robots/robots-production.txt
+++ b/docs/_robots/robots-production.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow: /_components/
 
 Sitemap: https://knowledge.dea.ga.gov.au/sitemap.xml

--- a/docs/_robots/robots-production.txt
+++ b/docs/_robots/robots-production.txt
@@ -1,3 +1,4 @@
 User-agent: *
+Disallow: /_components/
 
 Sitemap: https://knowledge.dea.ga.gov.au/sitemap.xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ exclude_patterns = [
     "**/_*",
     "**/*.scss",
     "_robots",
+    "_components",
     "data/archive",
     "notebooks/Scientific_workflows",
     "notebooks/DEA_notebooks_template.ipynb",


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Problem: 'Components' are being included in the site build and are being indexed as pages by Google. E.g.

* https://knowledge.dea.ga.gov.au/_components/sentinel-2c-replace-2a-alert/
* https://knowledge.dea.ga.gov.au/_components/thermal-bands-availability-faq/

Solution: Excluded configuration folder from Sphinx build.

Note: I've checked that the components still work as intended when they are embedded on pages. E.g. https://pr-390-preview.khpreview.dea.ga.gov.au/data/product/dea-surface-reflectance-sentinel-2a-msi/

Preview (a 404 page is expected):

* https://pr-390-preview.khpreview.dea.ga.gov.au/_components/sentinel-2c-replace-2a-alert/
* https://pr-390-preview.khpreview.dea.ga.gov.au/_components/thermal-bands-availability-faq/
