### PR TITLE
Product ID section in Specifications tab

### DIFF
--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -106,6 +106,8 @@
 
 {% set display_title = page.data.short_name if page.data.is_latest_version else page.data.short_name ~ " " ~ format_version_number(page.data.version_number) %}
 
+{% set product_ids_label = "Product IDs" if product_ids_list | length > 1 else "Product ID" %}
+
 {% set parent_products_label = "Parent products" if parent_products_list | length > 1 else "Parent product" %}
 
 {% set collections_label = "Collections" if collections_list | length > 1 else "Collection" %}
@@ -547,6 +549,13 @@
    .. list-table::
       :name: product-information-table
 
+      {% if product_ids_list %}
+      * - **{{ product_ids_label }}**
+        - {%- for product_id in product_ids_list %}
+          | {{ product_id }}
+          {%- endfor %}
+        - Used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_.
+      {%- endif %}
       * - **Short name**
         - {{ page.data.short_name }}
         - The name that is commonly used to refer to the product.

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -485,13 +485,13 @@
       :name: product-id
       :class: h2
 
-   The Product IDs are **{{ product_ids_list_text }}**. These are used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}**{{ product_id }}**{% endfor %}. These are used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- else %}
    .. rubric:: Product ID
       :name: product-id
       :class: h2
 
-   The Product ID is **{{ product_ids_list_text }}**. This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product ID is **{{ product_ids_list[0] }}**. This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- endif %}
    {%- endif %}
 

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -485,13 +485,13 @@
       :name: product-id
       :class: h2
 
-   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}**{{ product_id }}**{% endfor %}. These are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}``{{ product_id }}``{% endfor %}. These are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- else %}
    .. rubric:: Product ID
       :name: product-id
       :class: h2
 
-   The Product ID is **{{ product_ids_list[0] }}**. This is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product ID is ``{{ product_ids_list[0] }}``. This is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- endif %}
 
    .. _load_data_odc: /notebooks/Beginners_guide/04_Loading_data/

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -485,13 +485,13 @@
       :name: product-id
       :class: h2
 
-   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}``{{ product_id }}``{% endfor %}. These are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}``{{ product_id }}``{% endfor %}. These IDs are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- else %}
    .. rubric:: Product ID
       :name: product-id
       :class: h2
 
-   The Product ID is ``{{ product_ids_list[0] }}``. This is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product ID is ``{{ product_ids_list[0] }}``. This ID is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- endif %}
 
    .. _load_data_odc: /notebooks/Beginners_guide/04_Loading_data/

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -485,14 +485,16 @@
       :name: product-id
       :class: h2
 
-   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}**{{ product_id }}**{% endfor %}. These are used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}**{{ product_id }}**{% endfor %}. These are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- else %}
    .. rubric:: Product ID
       :name: product-id
       :class: h2
 
-   The Product ID is **{{ product_ids_list[0] }}**. This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product ID is **{{ product_ids_list[0] }}**. This is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- endif %}
+
+   .. _load_data_odc: /notebooks/Beginners_guide/04_Loading_data/
    {%- endif %}
 
    {% if bands_table_list %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -481,6 +481,16 @@
 
       <div class="product-tab-table-of-contents"></div>
 
+   {% if product_ids_list %}
+   .. rubric:: {{ product_ids_label }}
+      :name: product-id
+      :class: h2
+
+   The {{ product_ids_label }} are **{{ product_ids_list_text }}**.
+
+   This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_.
+   {%- endif %}
+
    {% if bands_table_list %}
    .. rubric:: Bands
       :name: bands
@@ -531,13 +541,6 @@
    .. list-table::
       :name: product-information-table
 
-      {% if product_ids_list %}
-      * - **{{ product_ids_label }}**
-        - {%- for product_id in product_ids_list %}
-          | {{ product_id }}
-          {%- endfor %}
-        - Used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_.
-      {%- endif %}
       * - **Short name**
         - {{ page.data.short_name }}
         - The name that is commonly used to refer to the product.

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -106,8 +106,6 @@
 
 {% set display_title = page.data.short_name if page.data.is_latest_version else page.data.short_name ~ " " ~ format_version_number(page.data.version_number) %}
 
-{% set product_ids_label = "Product IDs" if product_ids_list | length > 1 else "Product ID" %}
-
 {% set parent_products_label = "Parent products" if parent_products_list | length > 1 else "Parent product" %}
 
 {% set collections_label = "Collections" if collections_list | length > 1 else "Collection" %}
@@ -482,13 +480,19 @@
       <div class="product-tab-table-of-contents"></div>
 
    {% if product_ids_list %}
-   .. rubric:: {{ product_ids_label }}
+   {% if product_ids_list | length > 1 %}
+   .. rubric:: Product IDs
       :name: product-id
       :class: h2
 
-   The {{ product_ids_label }} are **{{ product_ids_list_text }}**.
+   The Product IDs are **{{ product_ids_list_text }}**. These are used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   {%- else %}
+   .. rubric:: Product ID
+      :name: product-id
+      :class: h2
 
-   This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_.
+   The Product ID is **{{ product_ids_list_text }}**. This is used to `load data from the Open Data Cube </notebooks/Beginners_guide/04_Loading_data/>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   {%- endif %}
    {%- endif %}
 
    {% if bands_table_list %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -485,13 +485,13 @@
       :name: product-id
       :class: h2
 
-   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}``{{ product_id }}``{% endfor %}. These IDs are used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product IDs are {% for product_id in product_ids_list %}{%- if loop.last and loop.index > 1 %}, and {% elif loop.index > 1 %}, {% endif -%}``{{ product_id }}``{% endfor %}. These IDs are used to `load data from the Open Data Cube (ODC) <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- else %}
    .. rubric:: Product ID
       :name: product-id
       :class: h2
 
-   The Product ID is ``{{ product_ids_list[0] }}``. This ID is used to `load data from the Open Data Cube <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
+   The Product ID is ``{{ product_ids_list[0] }}``. This ID is used to `load data from the Open Data Cube (ODC) <load_data_odc_>`_, for example ``dc.load(product="{{ product_ids_list[0] }}", ...)``
    {%- endif %}
 
    .. _load_data_odc: /notebooks/Beginners_guide/04_Loading_data/

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -502,7 +502,7 @@
       :name: bands
       :class: h2
 
-   Bands are distinct layers of data within a product that can be loaded using the Open Data Cube (on the `DEA Sandbox <dea_sandbox_>`_ or `NCI <nci_>`_) or DEA's `STAC API <stac_api_>`_.{{ " Note that the Coordinate Reference System (CRS) of these bands is {}.".format(coordinate_reference_system_term) if coordinate_reference_system_term }}{% if product_ids_list | length > 1 %} Here are the bands of the products: {{ product_ids_list_text }}.{%- elif product_ids_list %} Here are the bands of the product: {{ product_ids_list_text }}.{%- endif %}
+   Bands are distinct layers of data within a product that can be loaded using the Open Data Cube (on the `DEA Sandbox <dea_sandbox_>`_ or `NCI <nci_>`_) or DEA's `STAC API <stac_api_>`_.{{ " Note that the Coordinate Reference System (CRS) of these bands is {}.".format(coordinate_reference_system_term) if coordinate_reference_system_term }}
 
    .. _dea_sandbox: https://knowledge.dea.ga.gov.au/guides/setup/Sandbox/sandbox/
    .. _nci: https://knowledge.dea.ga.gov.au/guides/setup/NCI/basics/


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Problem:

* It is not immediately obvious what the Product ID is on the product pages.
* When the user clicks on the Product ID, they are taken to the Specifications tab which displays the bands at the top, and doesn't explain what the Product ID is until much lower on the page.

Solution:

* Add a Product ID section to the top of the Specifications tab.
* ~Remove the Product ID item from the Product information table since it is featured at the top.~

Previews:

* With single Product ID: https://pr-391-preview.khpreview.dea.ga.gov.au/data/product/dea-intertidal/?tab=specifications
* With multiple Product IDs: https://pr-391-preview.khpreview.dea.ga.gov.au/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/?tab=specifications
