### PR TITLE
Remove redundant bands content from product pages

### DIFF
--- a/docs/data/product/dea-coastlines/_description.md
+++ b/docs/data/product/dea-coastlines/_description.md
@@ -29,7 +29,7 @@ Annual shoreline vectors that represent the median or ‘most representative’ 
 
 Dashed shorelines have low certainty.
 
-Learn more about this layer in the [Specifications tab](./?tab=specifications).
+See the attributes of this layer in the [Specifications tab](./?tab=specifications).
 
 :::{figure} /_files/cmi/deacl_coastlines.*
 :alt: DEA CoastLines coastline layer
@@ -45,7 +45,7 @@ On the [interactive DEA Coastlines web map](https://maps.dea.ga.gov.au/story/DEA
 
 Rates of change points contains the following attribute columns that can be accessed by clicking on labelled points in the web map:
 
-Learn more about this layer in the [Specifications tab](./?tab=specifications).
+See the attributes of this layer in the [Specifications tab](./?tab=specifications).
 
 :::{figure} /_files/cmi/deacl_statistics_2.*
 :alt: DEA CoastLines rates of change statistics layer
@@ -57,7 +57,7 @@ Figure 2: Rates of change points from DEA Coastlines visualised on the [interact
 
 Three points layers summarising coastal change within moving 1 km, 5 km and 10 km windows along the coastline (Figure 3). These layers are useful for visualising regional or continental-scale patterns of coastal change. 
 
-Learn more about this layer in the [Specifications tab](./?tab=specifications).
+See the attributes of this layer in the [Specifications tab](./?tab=specifications).
 
 :::{figure} /_files/cmi/deacl_summary.*
 :alt: DEA CoastLines summary layer

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_description.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_description.md
@@ -59,27 +59,10 @@ The values for this product are as follows:
 * For the fractional cover bands (PV, NPV, BS)
 * 0-100 = fractional cover values that range between 0 and 100%
 
-Due to model uncertainties and the limitations of the training data, some areas may show cover values in excess of 100%. These areas can either be excluded or treated as equivalent to 100%
-
-The DEA Landsat Collection 3 Fractional Cover Percentiles Summary products share the following attributes:
-
-**Family name** : DEA Fractional Cover Percentiles
-
-| bands       | data type | nodata values | purpose                                               |
-|-------------|-----------|---------------|-------------------------------------------------------|
-| `bs_pc_10`  | uint8     | nodata 255    | bare soil - 10th percentile                           |
-| `pv_pc_10`  | uint8     | nodata 255    | photosynthetic veg - 10th percentile                  |
-| `npv_pc_10` | uint8     | nodata 255    | non-photosynthetic veg - 10th percentile              |
-| `bs_pc_50`  | uint8     | nodata 255    | bare soil - 50th percentile                           |
-| `pv_pc_50`  | uint8     | nodata 255    | photosynthetic veg - 50th percentile                  |
-| `npv_pc_50` | uint8     | nodata 255    | non-photosynthetic veg - 50th percentile              |
-| `bs_pc_90`  | uint8     | nodata 255    | bare soil - 90th percentile                           |
-| `pv_pc_90`  | uint8     | nodata 255    | photosynthetic veg - 90th percentile                  |
-| `npv_pc_90` | uint8     | nodata 255    | non-photosynthetic veg - 90th percentile              |
-| `qa`        | uint8     | nodata 255    | Quality Assurance enumeration - see below for details |
-
 ### Quality Assurance:
+
 This layer provides a breakdown of each FCP pixel between,
+
 * sufficient observations
 * insufficient observations dry
 * insufficient observations wet

--- a/docs/data/product/dea-intertidal/_description.md
+++ b/docs/data/product/dea-intertidal/_description.md
@@ -68,18 +68,7 @@ ga_s2ls_intertidal_cyear_3_x082y139_2022--P1Y_final_elevation.tif
 
 ### Core Product Layers 
 
-#### DEA Intertidal Elevation
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `elevation`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres above MSL`
-:::
+#### DEA Intertidal Elevation (elevation)
 
 DEA Intertidal Elevation (Figure 1) provides elevation in metre units relative to modelled Mean Sea Level for each pixel of the satellite-observed exposed intertidal zone across the Australian coastline. The elevation model is generated from DEA Landsat and Sentinel-2 surface reflectance data from each 3-year composite period, utilising a pixel-based approach based on [Ensemble Tidal Modelling](#ensemble-tidal-modelling). For every pixel, the time series of surface reflectance data is converted to the Normalised Difference Water Index (NDWI) and each observation tagged with the tidal height modelled at the time of acquisition by the satellite. A rolling median is applied from low to high tide to reduce noise (such as white water, sunglint, and non-tidal water level variability), then analysed to identify the tide height at which the pixel transitions from dry to wet. This tide height represents the elevation of the pixel.
 
@@ -89,18 +78,7 @@ DEA Intertidal Elevation (Figure 1) provides elevation in metre units relative t
 Figure 1 &mdash; DEA Intertidal Elevation, with low elevation values shown in dark colours and high elevation shown in light colours.
 :::
 
-#### DEA Intertidal Elevation Uncertainty
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `elevation_uncertainty`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres`
-:::
+#### DEA Intertidal Elevation Uncertainty (elevation_uncertainty)
 
 DEA Intertidal Elevation Uncertainty (Figure 2) provides a measure of the quality of each modelled elevation value in metre units. Uncertainty is calculated by assessing how cleanly the modelled elevation separates satellite observations into dry and wet observations. This is achieved by identifying satellite observations that were misclassified by the modelled elevation (for instance, pixels that were observed as wet at tide heights lower than the modelled elevation, or alternately, observed as dry at higher tide heights). The spread of tide heights from these misclassified observations is summarised using a robust Median Absolute Deviation (MAD) statistic, and reported as $0.5 \times MAD$ to represent one-sided uncertainty bounds (i.e. ± uncertainty on either side of the pixel's elevation). Common causes of high elevation uncertainty can be poor tidal model performance, rapidly changing intertidal morphology, or noisy underlying satellite data.
 
@@ -110,20 +88,7 @@ DEA Intertidal Elevation Uncertainty (Figure 2) provides a measure of the qualit
 Figure 2 &mdash; DEA Intertidal Elevation Uncertainty, with high uncertainty shown in light colours.
 :::
 
-#### DEA Intertidal Exposure
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `exposure`
-* - **Data type**
-  - `uint8`
-* - **Units**
-  - `percent`
-* - **'No data' value**
-  - `255`
-:::
+#### DEA Intertidal Exposure (exposure)
 
 DEA Intertidal Exposure (Figure 3) models the percentage of time that any intertidal pixel of known elevation is exposed from tidal inundation. Exposure is calculated by comparing the pixel elevation back against a high temporal resolution model of tide heights for that location, based on the [Ensemble Tidal Modelling](#ensemble-tidal-modelling) approach. Exposure percentage is calculated as the fraction of exposed observations relative to the total number of observations generated in the high temporal resolution tidal model for the 3-year product epoch.
 
@@ -133,56 +98,17 @@ DEA Intertidal Exposure (Figure 3) models the percentage of time that any intert
 Figure 3 &mdash; DEA Intertidal Exposure, with low exposure values (i.e. rarely exposed pixels) shown in dark colours.
 :::
 
-### Tidal Attribute Layers (ta)
+### Tidal Attribute Layers
 
-#### DEA Intertidal tidal spread
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_spread`
-* - **Data type**
-  - `uint8`
-* - **Units**
-  - `percent`
-* - **'No data' value**
-  - `255`
-:::
+#### DEA Intertidal tidal spread (ta_spread)
 
 The tidal spread dataset provides the percentage of the full astronomical tidal range observed by the time series of satellite observations at each pixel (see Figure 4a). DEA Intertidal Spread takes the concept of satellite tide bias, introduced in Bishop-Taylor et al (2019), and applies it at a pixel scale to demonstrate the fraction of the full tide range that was sensor observed during the analysis epoch at that location. In this work, the astronomical tide range is defined as that modelled by the [Ensemble Tidal Modelling](#ensemble-tidal-modelling) approach. 
 
-#### DEA Intertidal low tide offset
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_offset_low`
-* - **Data type**
-  - `uint8`
-* - **Units**
-  - `percent`
-* - **'No data' value**
-  - `255`
-:::
+#### DEA Intertidal low tide offset (ta_offset_low)
 
 The low tide offset dataset quantifies the proportion of the lowest tides not observed at any time during the analysis epoch by satellites at each pixel (as a percentage of the astronomical tide range). It is calculated by measuring the offset between the lowest astronomical tide (LAT) and the lowest satellite-observed tide (LOT; see Figure 4b). A high value indicates that DEA Intertidal datasets may not map the lowest regions of the intertidal zone.
 
-#### DEA Intertidal high tide offset
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_offset_high`
-* - **Data type**
-  - `uint8`
-* - **Units**
-  - `percent`
-* - **'No data' value**
-  - `255`
-:::
+#### DEA Intertidal high tide offset (ta_offset_high)
 
 The high tide offset dataset quantifies the proportion of the highest tides not observed at any time during the analysis epoch by satellites at each pixel (as a percentage of the astronomical tide range). It is calculated by measuring the offset between the highest astronomical tide (HAT) and the highest satellite-observed tide (HOT; see Figure 4c). A high value indicates that DEA Intertidal datasets may not map the highest regions of the intertidal zone.
 
@@ -192,97 +118,29 @@ The high tide offset dataset quantifies the proportion of the highest tides no
 Figure 4 &mdash; Illustration of the concept of observed tide heights (dots corresponding to satellite acquisition time) compared to the full modelled tidal range (blue lines). Descriptions of Spread (a), Lowtide offset (b), and Hightide offset (c) are detailed in the text.
 :::
 
-#### DEA Intertidal lowest observed tide
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_lot`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres above MSL`
-:::
+#### DEA Intertidal lowest observed tide (ta_lot)
 
 The lowest observed tide dataset maps the lowest satellite-observed tide (LOT) of the satellite time series at each pixel during the analysis epoch, based on [Ensemble Tidal Modelling](#ensemble-tidal-modelling).
 
-#### DEA Intertidal highest observed tide
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_hot`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres above MSL`
-:::
+#### DEA Intertidal highest observed tide (ta_hot)
 
 The highest observed tide dataset maps the highest satellite-observed tide (HOT) of the satellite time-series at each pixel during the analysis epoch, based on [Ensemble Tidal Modelling](#ensemble-tidal-modelling).
 
-#### DEA Intertidal lowest astronomical tide
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_lat`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres above MSL`
-:::
+#### DEA Intertidal lowest astronomical tide (ta_lat)
 
 The lowest astronomical tide dataset maps the lowest astronomical tide (LAT) for each pixel, as modelled by the [Ensemble Tidal Model](#ensemble-tidal-modelling) for the analysis epoch. Note that the LAT modelled for each individual analysis epoch may differ from the LAT modelled across ‘all time’ for any given location.
 
-#### DEA Intertidal highest astronomical tide
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `ta_hat`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `metres above MSL`
-:::
+#### DEA Intertidal highest astronomical tide (ta_hat)
 
 The highest astronomical tide dataset maps the highest astronomical tide (HAT) for each pixel, as modelled by the Ensemble Tidal Model for the analysis epoch. Note that the HAT modelled for each individual analysis epoch may differ from the HAT modelled across ‘all time’ for any given location.
 
-### Quality Assessment Layers (qa) 
+### Quality Assessment Layers
 
-##### DEA Intertidal NDWI frequency
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `qa_ndwi_freq`
-* - **Data type**
-  - `uint8`
-* - **Units**
-  - `percent`
-* - **'No data' value**
-  - `255`
-:::
+##### DEA Intertidal NDWI frequency (qa_ndwi_freq)
 
 This quality assessment band provides the inundation frequency of each pixel across the analysis epoch, as measured by NDWI. High values indicate that a pixel was observed as being inundated regularly in satellite observations.
 
-#### DEA Intertidal NDWI correlation
-
-:::{list-table}
-:class: small
-
-* - **Name**
-  - `qa_ndwi_corr`
-* - **Data type**
-  - `float32`
-* - **Units**
-  - `correlation`
-:::
+#### DEA Intertidal NDWI correlation (qa_ndwi_corr)
 
 This quality assessment dataset provides pixel-level Pearson correlations between NDWI satellite observations and tide heights from the [Ensemble Tidal Model](#ensemble-tidal-modelling) over the analysis epoch. High values indicate that patterns of inundation were positively correlated with tide, indicating that the pixel was likely to be tidally influenced.
 

--- a/docs/data/product/dea-intertidal/_description.md
+++ b/docs/data/product/dea-intertidal/_description.md
@@ -68,6 +68,8 @@ ga_s2ls_intertidal_cyear_3_x082y139_2022--P1Y_final_elevation.tif
 
 ### Core Product Layers 
 
+See the attributes of these layers in the [Specifications tab](./?tab=specifications).
+
 #### DEA Intertidal Elevation (elevation)
 
 DEA Intertidal Elevation (Figure 1) provides elevation in metre units relative to modelled Mean Sea Level for each pixel of the satellite-observed exposed intertidal zone across the Australian coastline. The elevation model is generated from DEA Landsat and Sentinel-2 surface reflectance data from each 3-year composite period, utilising a pixel-based approach based on [Ensemble Tidal Modelling](#ensemble-tidal-modelling). For every pixel, the time series of surface reflectance data is converted to the Normalised Difference Water Index (NDWI) and each observation tagged with the tidal height modelled at the time of acquisition by the satellite. A rolling median is applied from low to high tide to reduce noise (such as white water, sunglint, and non-tidal water level variability), then analysed to identify the tide height at which the pixel transitions from dry to wet. This tide height represents the elevation of the pixel.
@@ -99,6 +101,8 @@ Figure 3 &mdash; DEA Intertidal Exposure, with low exposure values (i.e. rarely 
 :::
 
 ### Tidal Attribute Layers
+
+See the attributes of these layers in the [Specifications tab](./?tab=specifications).
 
 #### DEA Intertidal tidal spread (ta_spread)
 
@@ -135,6 +139,8 @@ The lowest astronomical tide dataset maps the lowest astronomical tide (LAT) for
 The highest astronomical tide dataset maps the highest astronomical tide (HAT) for each pixel, as modelled by the Ensemble Tidal Model for the analysis epoch. Note that the HAT modelled for each individual analysis epoch may differ from the HAT modelled across ‘all time’ for any given location.
 
 ### Quality Assessment Layers
+
+See the attributes of these layers in the [Specifications tab](./?tab=specifications).
 
 ##### DEA Intertidal NDWI frequency (qa_ndwi_freq)
 


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

These two product pages were identified to contain bands content that is now redundant due to the new Specifications tab (Preview):

* https://pr-395-preview.khpreview.dea.ga.gov.au/data/product/dea-intertidal/?tab=description
* https://pr-395-preview.khpreview.dea.ga.gov.au/data/product/dea-fractional-cover-percentiles-landsat/?tab=description