### PR TITLE
Changed the punctuation after version number in old version title

### DIFF
--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -28,7 +28,7 @@
 {% set has_access_data = valid_maps or valid_data or valid_explorers or valid_web_services or valid_code_samples or valid_custom %}
 {% set has_key_details = (data.parent_products.name and data.parent_products.link) or (data.collection.name and data.collection.link) or data.collection.name or data.doi or data.ecat or data.published %}
 
-{% set page_title = data.title if is_latest_version else "v" + data.version + " " + data.title %}
+{% set page_title = data.title if is_latest_version else "v" + data.version + " - " + data.title %}
 {% set display_title = data.title if is_latest_version else data.title + " v" + data.version %}
 
 {% set product_ids_label = "Product IDs" if valid_product_ids | length > 1 else "Product ID" %}

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -28,7 +28,7 @@
 {% set has_access_data = valid_maps or valid_data or valid_explorers or valid_web_services or valid_code_samples or valid_custom %}
 {% set has_key_details = (data.parent_products.name and data.parent_products.link) or (data.collection.name and data.collection.link) or data.collection.name or data.doi or data.ecat or data.published %}
 
-{% set page_title = data.title if is_latest_version else "v" + data.version + ": " + data.title %}
+{% set page_title = data.title if is_latest_version else "v" + data.version + " " + data.title %}
 {% set display_title = data.title if is_latest_version else data.title + " v" + data.version %}
 
 {% set product_ids_label = "Product IDs" if valid_product_ids | length > 1 else "Product ID" %}

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -112,7 +112,7 @@
 
 {% set layers_count = layers_table_list | length %}
 
-{% set page_title = page.data.short_name if page.data.is_latest_version else format_version_number(page.data.version_number) ~ ". " ~ page.data.short_name %}
+{% set page_title = page.data.short_name if page.data.is_latest_version else format_version_number(page.data.version_number) ~ " " ~ page.data.short_name %}
 
 {% set display_title = page.data.short_name if page.data.is_latest_version else page.data.short_name ~ " " ~ format_version_number(page.data.version_number) %}
 

--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -112,7 +112,7 @@
 
 {% set layers_count = layers_table_list | length %}
 
-{% set page_title = page.data.short_name if page.data.is_latest_version else format_version_number(page.data.version_number) ~ " " ~ page.data.short_name %}
+{% set page_title = page.data.short_name if page.data.is_latest_version else format_version_number(page.data.version_number) ~ " - " ~ page.data.short_name %}
 
 {% set display_title = page.data.short_name if page.data.is_latest_version else page.data.short_name ~ " " ~ format_version_number(page.data.version_number) %}
 


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

The Version History sidebar has been changed from displaying "v1.0.0: Page title" and "v1.0.0. Page title" to "v1.0.0 - Page title" because it looks nicer and in order to standardise both the V1 and V2 templates to use the same punctuation.

Preview: https://pr-405-preview.khpreview.dea.ga.gov.au/data/version-history/