### PR TITLE
GeoMAD temporal extent end = 2024

### DIFF
--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -15,7 +15,7 @@ spatial_data_type: RASTER
 
 spatial_coverage: null
 temporal_coverage_start: 1986
-temporal_coverage_end: Present
+temporal_coverage_end: 2024
 temporal_coverage_custom: null
 
 data_update_frequency: YEARLY


### PR DESCRIPTION
updating GeoMad on KH - add 2024 to coverage end date

Preview: https://pr-415-preview.khpreview.dea.ga.gov.au/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/

<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

