### PR TITLE
Remove tags from Key specifications table

### DIFF
--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -156,12 +156,6 @@
 {% for collection in collections_list %}{% if collection.link %}`{{ collection.name }} <{{ collection.link }}>`_{% else %}{{ collection.name }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 {%- endset %}
 
-{# Tags list component #}
-
-{% set tags_list_component -%}
-{% for tag in tags_list %}`{{tag}} </search/?q=Tag+{{tag}}>`_{% if not loop.last %}, {% endif %}{% endfor %}
-{%- endset %}
-
 {# Restructured Text head component #}
 
 {% set rst_head_component %}
@@ -409,10 +403,6 @@
       {%- if collections_list %}
       * - **{{ collections_label }}**
         - {{ collections_list_component }}
-      {%- endif %}
-      {%- if tags_list %}
-      * - **Tags**
-        - {{ tags_list_component }}
       {%- endif %}
       {%- if page.data.licence_name and page.data.licence_link %}
       * - **Licence**
@@ -754,7 +744,7 @@
       {%- endif %}
       {%- if tags_list %}
       * - **Tags**
-        - {{ tags_list_component }}
+        - {% for tag in tags_list %}`{{tag}} </search/?q=Tag+{{tag}}>`_{% if not loop.last %}, {% endif %}{% endfor %}
       {%- endif %}
 
 {% endif %}


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

The reasons for this proposed change:

* Tags are already featured in the Specifications tab
* Tags aren't important enough to be on the Overview tab
* Tags are visually too similar to the Bands/Layers which area also featured in the Key specifications table, and those are much more important.
* The Key specifications table is getting crowded.

Preview: https://pr-416-preview.khpreview.dea.ga.gov.au/data/product/dea-intertidal/#key-specifications