### PR TITLE
Updated banner now that S2C is released: Sentinel-2C is replacing Sentinel-2A

### DIFF
--- a/docs/_components/sentinel-2c-replace-2a-alert.md
+++ b/docs/_components/sentinel-2c-replace-2a-alert.md
@@ -1,5 +1,7 @@
-:::{admonition} Sentinel-2C is replacing Sentinel-2A
+:::{admonition} Sentinel-2C has replaced Sentinel-2A
 :class: warning
 
-This Sentinel-2A product will **stop publishing data updates on 21 January 2025**. It is being replaced by a new Sentinel-2C product which will start publishing data updates shortly thereafter.
+This Sentinel-2A product has **stopped publishing data updates on 21 January 2025**. It has been replaced by the new [Sentinel-2C products](https://knowledge.dea.ga.gov.au/data/category/sentinel-2c-analysis-ready-data/).
+
+[View the Sentinel-2C Analysis Ready Data products](https://knowledge.dea.ga.gov.au/data/category/sentinel-2c-analysis-ready-data/)
 :::

--- a/docs/_components/sentinel-2c-replace-2a-alert.md
+++ b/docs/_components/sentinel-2c-replace-2a-alert.md
@@ -1,7 +1,7 @@
 :::{admonition} Switch-over to Sentinel-2C
 :class: warning
 
-This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products ([ga_s2cm_ard_3](/data/product/dea-surface-reflectance-sentinel-2c-msi/)). We encourage you to switch to using these new Sentinel-2C products.
+This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products. We encourage you to switch to using these new Sentinel-2C products.
 
-[View the Sentinel-2C Analysis Ready Data products](/data/category/sentinel-2c-analysis-ready-data/)
+[View the Sentinel-2C Analysis Ready Data products (ga_s2cm_ard_3)](/data/category/sentinel-2c-analysis-ready-data/)
 :::

--- a/docs/_components/sentinel-2c-replace-2a-alert.md
+++ b/docs/_components/sentinel-2c-replace-2a-alert.md
@@ -1,7 +1,7 @@
 :::{admonition} Switch-over to Sentinel-2C
 :class: warning
 
-This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products. We encourage you to switch to using these new Sentinel-2C products.
+This Sentinel-2A product stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products. We encourage you to switch to using these new Sentinel-2C products.
 
 [View the Sentinel-2C Analysis Ready Data products (ga_s2cm_ard_3)](/data/category/sentinel-2c-analysis-ready-data/)
 :::

--- a/docs/_components/sentinel-2c-replace-2a-alert.md
+++ b/docs/_components/sentinel-2c-replace-2a-alert.md
@@ -1,7 +1,7 @@
 :::{admonition} Switch-over to Sentinel-2C
 :class: warning
 
-This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products ([ga_s2cm_ard_3](/data/product/dea-surface-reflectance-sentinel-2c-msi/)).
+This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products ([ga_s2cm_ard_3](/data/product/dea-surface-reflectance-sentinel-2c-msi/)). We encourage you to switch to using these new Sentinel-2C products.
 
 [View the Sentinel-2C Analysis Ready Data products](/data/category/sentinel-2c-analysis-ready-data/)
 :::

--- a/docs/_components/sentinel-2c-replace-2a-alert.md
+++ b/docs/_components/sentinel-2c-replace-2a-alert.md
@@ -1,7 +1,7 @@
-:::{admonition} Sentinel-2C has replaced Sentinel-2A
+:::{admonition} Switch-over to Sentinel-2C
 :class: warning
 
-This Sentinel-2A product has **stopped publishing data updates on 21 January 2025**. It has been replaced by the new [Sentinel-2C products](https://knowledge.dea.ga.gov.au/data/category/sentinel-2c-analysis-ready-data/).
+This Sentinel-2A product has stopped publishing data updates on 21 January 2025 and has been replaced by the new Sentinel-2C products ([ga_s2cm_ard_3](/data/product/dea-surface-reflectance-sentinel-2c-msi/)).
 
-[View the Sentinel-2C Analysis Ready Data products](https://knowledge.dea.ga.gov.au/data/category/sentinel-2c-analysis-ready-data/)
+[View the Sentinel-2C Analysis Ready Data products](/data/category/sentinel-2c-analysis-ready-data/)
 :::


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Updated banner to past tense and added links.

Preview: https://pr-420-preview.khpreview.dea.ga.gov.au/data/product/dea-surface-reflectance-sentinel-2a-msi/