### PR TITLE
Removed sparkles from Specifications tab

### DIFF
--- a/docs/_templates/product-v2.rst
+++ b/docs/_templates/product-v2.rst
@@ -490,7 +490,7 @@
 
 {% set specifications_tab_component %}
 {% if page.data.enable_specifications %}
-.. tab-item:: Specifications :raw-html:`&#x2728;`
+.. tab-item:: Specifications
    :name: specifications
 
    .. raw:: html


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Since the sparkles indicator has been on this tab for three months, that is long enough to introduce this new feature so now it's time to remove it.

Preview: https://pr-441-preview.khpreview.dea.ga.gov.au/data/product/dea-coastlines/