### PR TITLE
Fix cross-reference links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "myst_parser",
-    "nbsphinx",
+    # "nbsphinx",
     "sphinx_design",
     "sphinxext.rediraffe",
     "sphinxcontrib.datatemplates",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,26 +66,26 @@ html_permalinks = True
 html_last_updated_fmt = '%-d %B %Y' # E.g. 1 January 2020
 
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.autosummary",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
+    # "sphinx.ext.autodoc",
+    # "sphinx.ext.autosummary",
+    # "sphinx.ext.viewcode",
+    # "sphinx.ext.mathjax",
+    # "sphinx.ext.napoleon",
     "myst_parser",
     # "nbsphinx",
     "sphinx_design",
-    "sphinxext.rediraffe",
-    "sphinxcontrib.datatemplates",
-    "sphinx_external_toc",
-    "sphinx_sitemap",
-    "notfound.extension",
-    "sphinx_copybutton",
+    # "sphinxext.rediraffe",
+    # "sphinxcontrib.datatemplates",
+    # "sphinx_external_toc",
+    # "sphinx_sitemap",
+    # "notfound.extension",
+    # "sphinx_copybutton",
 ]
 
 myst_enable_extensions = [
     "colon_fence",
-    "attrs_inline",
-    "attrs_block",
+    # "attrs_inline",
+    # "attrs_block",
     "dollarmath",
 ]
 myst_heading_anchors = 6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "myst_parser",
-    # "nbsphinx",
+    "nbsphinx",
     "sphinx_design",
     # "sphinxext.rediraffe",
     "sphinxcontrib.datatemplates",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,20 +66,20 @@ html_permalinks = True
 html_last_updated_fmt = '%-d %B %Y' # E.g. 1 January 2020
 
 extensions = [
-    # "sphinx.ext.autodoc",
-    # "sphinx.ext.autosummary",
-    # "sphinx.ext.viewcode",
-    # "sphinx.ext.mathjax",
-    # "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     "myst_parser",
     # "nbsphinx",
     "sphinx_design",
     # "sphinxext.rediraffe",
-    # "sphinxcontrib.datatemplates",
-    # "sphinx_external_toc",
-    # "sphinx_sitemap",
-    # "notfound.extension",
-    # "sphinx_copybutton",
+    "sphinxcontrib.datatemplates",
+    "sphinx_external_toc",
+    "sphinx_sitemap",
+    "notfound.extension",
+    "sphinx_copybutton",
 ]
 
 myst_enable_extensions = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "myst_parser",
-    "nbsphinx",
+    # "nbsphinx",
     "sphinx_design",
     # "sphinxext.rediraffe",
     "sphinxcontrib.datatemplates",
@@ -84,8 +84,8 @@ extensions = [
 
 myst_enable_extensions = [
     "colon_fence",
-    # "attrs_inline",
-    # "attrs_block",
+    "attrs_inline",
+    "attrs_block",
     "dollarmath",
 ]
 myst_heading_anchors = 6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ if is_production: html_baseurl = "https://knowledge.dea.ga.gov.au/"
 elif is_pr_preview: html_baseurl = f"https://{pr_preview_subdomain}.khpreview.dea.ga.gov.au/"
 else: html_baseurl = ""
 
-html_permalinks = False
+html_permalinks = True
 html_last_updated_fmt = '%-d %B %Y' # E.g. 1 January 2020
 
 extensions = [
@@ -89,7 +89,7 @@ myst_enable_extensions = [
     "dollarmath",
 ]
 myst_heading_anchors = 6
-myst_all_links_external = True
+myst_all_links_external = False
 
 nbsphinx_requirejs_path = ""
 nbsphinx_execute = "never"

--- a/docs/guides/land-cover-explorer.md
+++ b/docs/guides/land-cover-explorer.md
@@ -2,8 +2,6 @@
 
 [Test link: DEA Maps](#dea-maps)
 
-@dea-maps
-
 [Land Cover Explorer][Explorer] is a web application in the [Digital Atlas of Australia](https://digital.atlas.gov.au/), developed by Esri. It allows you to navigate and visualise the [DEA Land Cover][LandCover] datasets. (This is an easy alternative to [plotting Land Cover data yourself](/notebooks/DEA_products/DEA_Land_Cover/).)
 
 :::{admonition} Start exploring

--- a/docs/guides/land-cover-explorer.md
+++ b/docs/guides/land-cover-explorer.md
@@ -2,6 +2,8 @@
 
 [Test link: DEA Maps](#dea-maps)
 
+@dea-maps
+
 [Land Cover Explorer][Explorer] is a web application in the [Digital Atlas of Australia](https://digital.atlas.gov.au/), developed by Esri. It allows you to navigate and visualise the [DEA Land Cover][LandCover] datasets. (This is an easy alternative to [plotting Land Cover data yourself](/notebooks/DEA_products/DEA_Land_Cover/).)
 
 :::{admonition} Start exploring

--- a/docs/guides/land-cover-explorer.md
+++ b/docs/guides/land-cover-explorer.md
@@ -1,5 +1,7 @@
 # Land Cover Explorer
 
+[Test link: DEA Maps](#dea-maps)
+
 [Land Cover Explorer][Explorer] is a web application in the [Digital Atlas of Australia](https://digital.atlas.gov.au/), developed by Esri. It allows you to navigate and visualise the [DEA Land Cover][LandCover] datasets. (This is an easy alternative to [plotting Land Cover data yourself](/notebooks/DEA_products/DEA_Land_Cover/).)
 
 :::{admonition} Start exploring

--- a/docs/guides/setup/dea_maps.md
+++ b/docs/guides/setup/dea_maps.md
@@ -1,3 +1,5 @@
+(dea-maps)=
+
 # DEA Maps
 
 [DEA Maps](https://maps.dea.ga.gov.au/) is an online platform where you can view Digital Earth Australia (DEA) datasets. It aims to make it easy for anyone to access our open-source data &mdash; whether you are a scientist, educator, journalist, or otherwise.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx<=7.2.6
-nbsphinx<=0.9.1
+nbsphinx<=0.9.7
 ipython<=8.18.1
 myst-parser<=2.0.0
 ipywidgets<=8.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx<=7.2.6
-nbsphinx<=0.9.3
+nbsphinx<=0.9.1
 ipython<=8.18.1
 myst-parser<=2.0.0
 ipywidgets<=8.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx<=7.2.6
-nbsphinx<=0.9.1
+nbsphinx<=0.9.1 # Cross-references of the format [Test link](#test-label) break in 0.9.2.
 ipython<=8.18.1
 myst-parser<=2.0.0
 ipywidgets<=8.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx<=7.2.6
-nbsphinx<=0.9.7
+nbsphinx<=0.9.1
 ipython<=8.18.1
 myst-parser<=2.0.0
 ipywidgets<=8.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx<=7.2.6
-nbsphinx<=0.9.1 # Cross-references of the format [Test link](#test-label) break in 0.9.2.
+nbsphinx<=0.9.1 # Cross-references of the format [Test link](#test-label) break in 0.9.2. This bug still occurs in 0.9.7. Issue: https://github.com/spatialaudio/nbsphinx/issues/748
 ipython<=8.18.1
 myst-parser<=2.0.0
 ipywidgets<=8.1.1


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

Fixed cross-reference links by reverting nbsphinx version from 0.9.2 to 0.9.1. I checked the DEA Notebooks to ensure that they are rendering properly.

Tests:

* https://pr-458-preview.khpreview.dea.ga.gov.au/guides/land-cover-explorer/