### PR TITLE
Improve DEA Maps access links

### DIFF
--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -55,7 +55,7 @@ tags:
 # Access
 
 access_links_maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-3qGgGRwBIgCnqDnPtOsN6T4UX5H # TODO review: https://maps.dea.ga.gov.au/#share=s-r7JEUiLzrVzwZIYcis6hVlMpDdT
+  - link: https://maps.dea.ga.gov.au/#share=s-r7JEUiLzrVzwZIYcis6hVlMpDdT
     name: See it on a map
 
 access_links_explorers:

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -56,7 +56,7 @@ tags:
 # Access
 
 access_links_maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-dsn0y5piVd34kvlDoOEEi1oSEWk # TODO review: https://maps.dea.ga.gov.au/#share=s-uTFeDOnmZpXV2Ub7kRC50Q0v4vj
+  - link: https://maps.dea.ga.gov.au/#share=s-uTFeDOnmZpXV2Ub7kRC50Q0v4vj
     name: See it on a map
 
 access_links_explorers:

--- a/docs/data/product/dea-mangroves/_data.yaml
+++ b/docs/data/product/dea-mangroves/_data.yaml
@@ -61,7 +61,7 @@ tags:
 # Access
 
 access_links_maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-riBc1GkNNMcUQoRWviu1Sst88or # TODO review: https://maps.dea.ga.gov.au/#share=s-1WoTW0dJY5MKU58ovTgOcZEYc48
+  - link: https://maps.dea.ga.gov.au/#share=s-ghl3uS1XtMVtyHg6LXSy6J3cklg
     name: null
 
 access_links_explorers:

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -58,7 +58,7 @@ tags:
 # Access
 
 access_links_maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-hnDwAfLNqJEIuwGzufL9yI5DS0w # TODO review: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
+  - link: https://maps.dea.ga.gov.au/#share=s-kpW2fu5nyh8hnS1M0OPsZ5lHlLi
     name: See it on a map
 
 access_links_explorers:

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -55,10 +55,9 @@ tags:
 
 # Access
 
-access_links_maps: null
-  # TODO review:
-  # - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
-  #   name: See it on a map
+access_links_maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-fVc2VkHndVr0xOVakjP0lzXdJsT
+    name: See it on a map
 
 access_links_explorers:
   - link: https://explorer.dea.ga.gov.au/products/ga_ls_wo_3

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -59,16 +59,15 @@ tags:
 
 # Access
 
-access_links_maps: null
-  # TODO review:
-  # - link: https://maps.dea.ga.gov.au/#share=s-yIyPPjQlWxVBLg10WJBQd8KrMgt
-  #   name: Apr-Oct summaries on DEA Maps
-  # - link: https://maps.dea.ga.gov.au/#share=s-vT2uXq2ZYxfuKzHZTYM7Xc9kXY0
-  #   name: Nov-Mar summaries on DEA Maps
-  # - link: https://maps.dea.ga.gov.au/#share=s-5fLlPp0Fk11iLTxUpCQPxTkVAH3
-  #   name: Annual calendar year summaries on DEA Maps
-  # - link: https://maps.dea.ga.gov.au/#share=s-x0R0IFIqxSFDJ54LK6sFDEfjh6i
-  #   name: All-time summary on DEA Maps
+access_links_maps:
+  - link: https://maps.dea.ga.gov.au/#share=s-yIyPPjQlWxVBLg10WJBQd8KrMgt
+    name: Apr-Oct summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-vT2uXq2ZYxfuKzHZTYM7Xc9kXY0
+    name: Nov-Mar summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-5fLlPp0Fk11iLTxUpCQPxTkVAH3
+    name: Annual calendar year summaries on DEA Maps
+  - link: https://maps.dea.ga.gov.au/#share=s-x0R0IFIqxSFDJ54LK6sFDEfjh6i
+    name: All-time summary on DEA Maps
 
 access_links_explorers:
   - link: https://explorer.dea.ga.gov.au/products#inland-water-group


### PR DESCRIPTION
<!--
* Please spell-check content, e.g. using Microsoft Word or Grammarly.
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/md_and_rst.html
-->

On the product pages, some of the DEA Maps share links were too zoomed out or were otherwise not user-friendly. I improved them so that they now show an appealing view of the product data. I avoided showing certain undesirable features of the data.

Preview:

* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-fractional-cover-landsat/
* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-fractional-cover-percentiles-landsat/
* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-mangroves/
* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-tasseled-cap-percentiles-landsat/
* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-water-observations-landsat/
* https://pr-465-preview.khpreview.dea.ga.gov.au/data/product/dea-water-observations-statistics-landsat/
