### PR TITLE
Add the Tidal Composites storymap link to KH

### DIFF
--- a/docs/data/product/dea-tidal-composites/_access.md
+++ b/docs/data/product/dea-tidal-composites/_access.md
@@ -8,6 +8,10 @@ DEA Tidal Composite data is extremely large with files up to 15 GB in size. We s
 
 :::{dropdown} How to view the data on DEA Maps
 
+Take a Storymap walk-through of the dataset to see some of its features and applications.
+
+- Open DEA Maps [Tidal Composites Storymap](https://maps.dea.ga.gov.au/story/DEATidalComposites)
+
 To add DEA Tidal Composites to DEA Maps manually:
 
 1. Open [DEA Maps](https://maps.dea.ga.gov.au/).

--- a/docs/data/product/dea-tidal-composites/_data.yaml
+++ b/docs/data/product/dea-tidal-composites/_data.yaml
@@ -68,7 +68,7 @@ tags:
 # Access 
 
 access_links_maps:
-  - link: https://maps.dea.ga.gov.au/#share=s-2Bvn7osEExcZbawi029aSeSqkyG
+  - link: https://maps.dea.ga.gov.au/story/DEATidalComposites
     name: See it on a map
 
 access_links_explorers:


### PR DESCRIPTION
# Background
DEA Tidal Composites now has a product specific storymap to demonstrate features and applications of the dataset.
# What's changed?
This minor update:
- Replaces the DEA Maps sharelink to the Tidal Composites dataset with the persistent url for the Tidal Composites storymap
- Adds a storymap link via the 'DEA Maps' dropdown menu to the dataset 'Access' options tab
# Preview
[KH Preview](https://pr-504-preview.khpreview.dea.ga.gov.au/)
