### PR TITLE
Added information on resampling algorithms for overviews

### DIFF
--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -25,6 +25,9 @@ This allows you to rapidly access data from the entire Australian continent with
 
 VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied.
 
+.. important::
+   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the `**MODE**` resampling algorithm. This means that when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
+   
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 
 ![Animation-showing-COG-zoom-in](/_files/land_cover/zoom_cog_landcover.gif) 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -25,11 +25,6 @@ This allows you to rapidly access data from the entire Australian continent with
 
 VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied.
 
-:::{admonition} Note
-:class: note
-
-   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
-
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 
 ![Animation-showing-COG-zoom-in](/_files/land_cover/zoom_cog_landcover.gif) 
@@ -38,6 +33,10 @@ For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF
     <figcaption>The animation above shows the DEA Land Cover COG mosaic moving from the continental-scale down to the 30m x 30m pixel level.</figcaption>
 </figure>
 
+:::{admonition} Note
+:class: note
+
+   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
 
 :::
 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -30,8 +30,6 @@ VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These f
 
    The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
 
-:::
-
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 
 ![Animation-showing-COG-zoom-in](/_files/land_cover/zoom_cog_landcover.gif) 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -38,6 +38,7 @@ For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF
     <figcaption>The animation above shows the DEA Land Cover COG mosaic moving from the continental-scale down to the 30m x 30m pixel level.</figcaption>
 </figure>
 
+
 :::
 
 :::{dropdown} How to integrate DEA Land Cover continental mosaics into your own Python workflow

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -38,6 +38,8 @@ For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF
     <figcaption>The animation above shows the DEA Land Cover COG mosaic moving from the continental-scale down to the 30m x 30m pixel level.</figcaption>
 </figure>
 
+:::
+
 :::{dropdown} How to integrate DEA Land Cover continental mosaics into your own Python workflow
 
 You can seamlessly open a Land Cover mosaic, such as Level 4 for year 2024, using Python and the `rioxarray` library. For example:

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -26,7 +26,7 @@ This allows you to rapidly access data from the entire Australian continent with
 VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied.
 
 .. important::
-   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
+   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
    
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -36,7 +36,7 @@ For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF
 :::{admonition} Note
 :class: note
 
-   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
+The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
 
 :::
 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -26,7 +26,7 @@ This allows you to rapidly access data from the entire Australian continent with
 VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied.
 
 .. important::
-   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the `**MODE**` resampling algorithm. This means that when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
+   The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
    
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 

--- a/docs/data/product/dea-land-cover-landsat/_access.md
+++ b/docs/data/product/dea-land-cover-landsat/_access.md
@@ -25,9 +25,13 @@ This allows you to rapidly access data from the entire Australian continent with
 
 VRT (Virtual Raster) files are also provided alongside the .tif mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied.
 
-.. important::
+:::{admonition} Note
+:class: note
+
    The overviews (pyramid layers) embedded in the DEA Land Cover COG mosaics were generated using the **MODE** resampling algorithm. This means that, when viewing the data at coarser zoom levels, each overview pixel is assigned the most common land cover class within its corresponding area.
-   
+
+:::
+
 For detailed instructions, please visit the [Continental Cloud-Optimised GeoTIFF Mosaics page](/guides/continental-cogs-geotiff-mosaics/)
 
 ![Animation-showing-COG-zoom-in](/_files/land_cover/zoom_cog_landcover.gif) 

--- a/docs/guides/continental-cogs-geotiff-mosaics.rst
+++ b/docs/guides/continental-cogs-geotiff-mosaics.rst
@@ -11,7 +11,7 @@ COGs include overviews, which are lower-resolution pyramid layers that allow fas
 
 - **MODE** – used for **categorical data**; assigns the most frequent value within the extent of an overview pixel.
 - **BILINEAR** – used for **continuous data** with minimal missing values; interpolates pixels to produce a smooth gradient.
-- **NEAREST** – used for **continuous or categorical data with many missing values**; each overview pixel takes the value of the higher-resolution pixel closest to its centroid. This algorithm maximises the visualisation of products where valid pixels are surrounded by many no-data pixels. Using a different algorithm would, in most cases, cause no-data values to dominate high-level overviews.
+- **NEAREST** – used for **continuous or categorical data with many missing values**; each overview pixel takes the value of the higher-resolution pixel closest to its centroid. This algorithm appears to maximise the visualisation of products where valid pixels are surrounded by many no-data pixels.
 
 Not all DEA products provide continental-scale COGs. Currently, this access method is only available for selected products:
 

--- a/docs/guides/continental-cogs-geotiff-mosaics.rst
+++ b/docs/guides/continental-cogs-geotiff-mosaics.rst
@@ -7,11 +7,17 @@ Some Digital Earth Australia (DEA) products are provided as **continental-scale 
 
 These datasets are made available as **Cloud-Optimised GeoTIFFs (COGs)**, a format that enables users to efficiently *stream* raster data directly from the cloud without downloading the files. This provides a fast and convenient way to access full-continental coverage from tools like QGIS or ArcGIS Pro, especially when working with large datasets.
 
+COGs include overviews, which are lower-resolution pyramid layers that allow fast rendering at different zoom levels. When zooming out, GIS software displays a coarser overview to improve performance. These layers are generated using a **resampling algorithm**, which determines how pixel values are aggregated when reducing spatial resolution. For DEA products, the choice of resampling algorithm depends on the nature of the data:
+
+- **MODE** – used for **categorical data**; assigns the most frequent value within the extent of an overview pixel.
+- **BILINEAR** – used for **continuous data** with minimal missing values; interpolates pixels to produce a smooth gradient.
+- **NEAREST** – used for **continuous data with a "narrow" appearance**; each overview pixel takes the value of the higher-resolution pixel closest to its centroid. This algorithm maximises the visualisation of products where valid pixels are surrounded by many no-data pixels. Using a different algorithm would, in most cases, cause no-data values to dominate high-level overviews.
+
 Not all DEA products provide continental-scale COGs. Currently, this access method is only available for selected products:
 
-- `DEA Land Cover </data/product/dea-land-cover-landsat/>`_
-- `DEA Intertidal </data/product/dea-intertidal/>`_
-- `DEA Tidal Composites </data/product/dea-tidal-composites/>`_
+- `DEA Land Cover </data/product/dea-land-cover-landsat/>`_ - uses `MODE` as the overview resampling algorithm
+- `DEA Intertidal </data/product/dea-intertidal/>`_ - uses `NEAREST` as the overview resampling algorithm
+- `DEA Tidal Composites </data/product/dea-tidal-composites/>`_ - uses `NEAREST` as the overview resampling algorithm
 
 **VRT (Virtual Raster) files** are provided alongside the ``.tif`` mosaics. These files serve as lightweight wrappers around the main data and can be used to open data in GIS software with visual settings already applied. We use VRTs to provide:
 

--- a/docs/guides/continental-cogs-geotiff-mosaics.rst
+++ b/docs/guides/continental-cogs-geotiff-mosaics.rst
@@ -11,7 +11,7 @@ COGs include overviews, which are lower-resolution pyramid layers that allow fas
 
 - **MODE** – used for **categorical data**; assigns the most frequent value within the extent of an overview pixel.
 - **BILINEAR** – used for **continuous data** with minimal missing values; interpolates pixels to produce a smooth gradient.
-- **NEAREST** – used for **continuous data with a "narrow" appearance**; each overview pixel takes the value of the higher-resolution pixel closest to its centroid. This algorithm maximises the visualisation of products where valid pixels are surrounded by many no-data pixels. Using a different algorithm would, in most cases, cause no-data values to dominate high-level overviews.
+- **NEAREST** – used for **continuous or categorical data with many missing values**; each overview pixel takes the value of the higher-resolution pixel closest to its centroid. This algorithm maximises the visualisation of products where valid pixels are surrounded by many no-data pixels. Using a different algorithm would, in most cases, cause no-data values to dominate high-level overviews.
 
 Not all DEA products provide continental-scale COGs. Currently, this access method is only available for selected products:
 


### PR DESCRIPTION
I noticed that previously I didn't include any information of the resampling algorithm used. As the mosaics seem to become more popular and considering the new notebook that shows how to access overviews arrays, I think it's important to explain that different DEA products use different algorithms.

I have updated the generic section of the KH and listed the algorithm used in the DEA products offered as mosaics. And I have also added the resampling algorithm in the Land Cover access page, to make that information visible even when people won't click on the general info page.

Please @robbibt, @erialC-P , or @vnewey , double check if I listed the correct algorithm for your products in the general content!

Previews:
general content in user guides --> https://pr-509-preview.khpreview.dea.ga.gov.au/guides/continental-cogs-geotiff-mosaics/
LC access page (under "How to stream DEA Land Cover continental mosaics ...) --> https://pr-509-preview.khpreview.dea.ga.gov.au/data/product/dea-land-cover-landsat/?tab=access
