### PR TITLE
Minor fix for year of DEA Coastlines version upgrade

### DIFF
--- a/docs/data/product/dea-coastlines/_history.md
+++ b/docs/data/product/dea-coastlines/_history.md
@@ -2,7 +2,7 @@
 
 ### DEA Coastlines 3.1.0 and 2025 annual data
 
-In April 2025, the DEA Coastlines product [was upgraded to version 3.1.0](https://github.com/GeoscienceAustralia/dea-coastlines/releases/tag/3.1.0). 
+In April 2026, the DEA Coastlines product [was upgraded to version 3.1.0](https://github.com/GeoscienceAustralia/dea-coastlines/releases/tag/3.1.0). 
 This upgrade consists of the addition of interim annual shoreline data for 2025. The 2025 shoreline is interim data that is subject to change, and will be updated to a final version in the next DEA Coastlines upgrade (April 2027). You are now able to [access the latest data](./?tab=access) via DEA Maps and other methods. 
 
 ### 10 Sep 2025: DEA data in the Digital Atlas of Australia


### PR DESCRIPTION
Correct the year of the DEA Coastlines upgrade from 2025 to 2026.

<!--
* Please spell-check your content (e.g. using Grammarly or Microsoft Word).
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/general/markdown-rst-cheatsheet/
-->

