### PR TITLE
Add NCI data access link to tidal composites

### DIFF
--- a/docs/data/product/dea-tidal-composites/_data.yaml
+++ b/docs/data/product/dea-tidal-composites/_data.yaml
@@ -91,6 +91,9 @@ access_links_custom:
     link: ./?tab=access#access-guides
     name: How to stream data from AWS
     description: null
+  - type: data
+    link: https://thredds.nci.org.au/thredds/catalog/jw04/ga_s2_tidal_composites_cyear_3/catalog.html
+    name: Access the data on NCI
 
   - type: code_example
     link: https://github.com/GeoscienceAustralia/dea-intertidal


### PR DESCRIPTION
Now that Tidal Composites is available on the NCI, we can add it as an access link:

Preview: https://pr-566-preview.khpreview.dea.ga.gov.au/data/product/dea-tidal-composites/?tab=access

<img width="899" height="377" alt="image" src="https://github.com/user-attachments/assets/5501d3c3-fe43-4e1c-9699-fd3110a3be9f" />

