### PR TITLE
Add mangrove patching to history section

### DIFF
--- a/docs/data/product/dea-land-cover-landsat/_history.md
+++ b/docs/data/product/dea-land-cover-landsat/_history.md
@@ -5,7 +5,7 @@
 
 ### 29 Apr 2026: Patching of misclassified data
 
-The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records.
+The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records. [View the Tech Alert](https://communication.ga.gov.au/link/id/zzzz69deeb5f9e03e642Pzzzz5c490cd32e49a595/page.html)
 
 ### 10 Sep 2025: DEA Land Cover continental mosaics
 

--- a/docs/data/product/dea-land-cover-landsat/_history.md
+++ b/docs/data/product/dea-land-cover-landsat/_history.md
@@ -3,6 +3,10 @@
 :::{include} ../../../_components/tech-alert-terrestrial-2025-annual-product-update-summary.md
 :::
 
+### 29 Apr 2026: Patching of misclassified data
+
+The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records.
+
 ### 10 Sep 2025: DEA Land Cover continental mosaics
 
 We've added a new way to access our [DEA Land Cover](/data/product/dea-land-cover-landsat/) product; it is now available as continental mosaics, in Cloud-optimised GeoTIFF (COG) format. These mosaics provide a single-file representation of land cover data for **each year available** in the time series, removing the complexity of managing tiled datasets and making it easier to work with land cover data across Australia. 

--- a/docs/data/product/dea-mangroves/_history.md
+++ b/docs/data/product/dea-mangroves/_history.md
@@ -5,7 +5,7 @@
 
 ### 29 Apr 2026: Patching of misclassified data
 
-The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records.
+The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records. [View the Tech Alert](https://communication.ga.gov.au/link/id/zzzz69deeb5f9e03e642Pzzzz5c490cd32e49a595/page.html)
 
 ### 10 Sep 2025: DEA data in the Digital Atlas of Australia
 

--- a/docs/data/product/dea-mangroves/_history.md
+++ b/docs/data/product/dea-mangroves/_history.md
@@ -3,6 +3,10 @@
 :::{include} ../../../_components/tech-alert-terrestrial-2025-annual-product-update-summary.md
 :::
 
+### 29 Apr 2026: Patching of misclassified data
+
+The tile `x28y46` on the West Australian coast has been updated after a classification error was identified. Some areas of ocean in this tile were misclassified as mangroves and this has been corrected in the historical records.
+
 ### 10 Sep 2025: DEA data in the Digital Atlas of Australia
 
 The [DEA Coastlines](/data/product/dea-coastlines/), [DEA Mangroves](/data/product/dea-mangroves/), and [DEA Water Observations Multi-Year Summary](/data/product/dea-water-observations-statistics-landsat/) datasets have now been added to the Digital Atlas, joining [DEA Land Cover](/data/product/dea-land-cover-landsat/). This integration marks a significant milestone in how DEA data can be accessed, visualised, and applied. By embedding DEA products into the Digital Atlas, users can now interact with trusted Earth observation datasets alongside other authoritative national data — unlocking powerful new opportunities for cross-sector analysis and decision-making. 


### PR DESCRIPTION
Add the patching of `x28y46` for 1988-2005 due to misclassification. 

[Tech alert](https://communication.ga.gov.au/link/id/zzzz69deeb5f9e03e642Pzzzz5c490cd32e49a595/page.html) sent 15 Apr 2026.

CR 20260323.1 applied 28-29 Apr 2026.