### PR TITLE
Replaced GitHub shield with a link due to shields.io error "Unable to select next GitHub token from pool"

### DIFF
--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -42,7 +42,7 @@
         <div class="col-12 footer--github-repository">
             <div>
                 <ul>
-                    <li><a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GitHub repository: GeoscienceAustralia/dea-knowledge-hub</a></li>
+                    <li><a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">Source code (GitHub)</a></li>
                 </ul>
             </div>
         </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -39,9 +39,11 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-12 footer--badges">
+        <div class="col-12 footer--github-repository">
             <div>
-                <a title="GitHub repository" href="https://github.com/GeoscienceAustralia/dea-knowledge-hub"><img alt="GitHub License badge for GeoscienceAustralia/dea-knowledge-hub repository" src="https://img.shields.io/github/license/GeoscienceAustralia/dea-knowledge-hub?style=flat&logo=github&label=GeoscienceAustralia%2Fdea-knowledge-hub&labelColor=%23082e41&color=%230b5e4b"></a>
+                <ul>
+                    <li><a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">GitHub repository: GeoscienceAustralia/dea-knowledge-hub</a></li>
+                </ul>
             </div>
         </div>
     </div>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -41,6 +41,7 @@
     <div class="row">
         <div class="col-12 footer--github-repository">
             <div>
+                <hr>
                 <ul>
                     <li><a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">Source code (GitHub)</a></li>
                 </ul>

--- a/docs/_layouts/footer.html
+++ b/docs/_layouts/footer.html
@@ -41,7 +41,6 @@
     <div class="row">
         <div class="col-12 footer--github-repository">
             <div>
-                <hr>
                 <ul>
                     <li><a href="https://github.com/GeoscienceAustralia/dea-knowledge-hub">Source code (GitHub)</a></li>
                 </ul>

--- a/docs/_static/styles/components/_footer.scss
+++ b/docs/_static/styles/components/_footer.scss
@@ -72,6 +72,10 @@ footer.bd-footer {
             }
         }
 
+        &--github-repository {
+            margin-top: 1rem;
+        }
+
         &--copyright {
             & > p {
                 margin-top: 1rem;

--- a/docs/_static/styles/components/_footer.scss
+++ b/docs/_static/styles/components/_footer.scss
@@ -72,10 +72,6 @@ footer.bd-footer {
             }
         }
 
-        &--github-repository {
-            margin-top: 1rem;
-        }
-
         &--copyright {
             & > p {
                 margin-top: 1rem;

--- a/docs/_static/styles/components/_footer.scss
+++ b/docs/_static/styles/components/_footer.scss
@@ -60,7 +60,8 @@ footer.bd-footer {
 
         }
 
-        &--policy-links {
+        &--policy-links,
+        &--github-repository {
             li {
                 display: inline;
                 margin-right: 2rem;
@@ -68,12 +69,6 @@ footer.bd-footer {
                 @media only screen and (max-width: $breakpoint-xl) {
                     line-height: 2rem;
                 }
-            }
-        }
-
-        &--badges {
-            & > div {
-                margin-top: 1rem;
             }
         }
 


### PR DESCRIPTION
<!--
* Please spell-check your content (e.g. using Grammarly or Microsoft Word).
* See our Markdown cheat sheet: https://docs.dev.dea.ga.gov.au/general/markdown-rst-cheatsheet/
-->

The 'GitHub shield' in the footer is displaying an error "Unable to select next GitHub token from pool" which seemingly is coming from the external server of the shields.io badge. So since this external service is unreliable, I think it's better just to remove it and replace it with a normal link.

https://pr-576-preview.khpreview.dea.ga.gov.au/